### PR TITLE
Several changes to mediator.py

### DIFF
--- a/mediator.py
+++ b/mediator.py
@@ -1,11 +1,12 @@
 """http://dpip.testingperspective.com/?p=28"""
 
+import random
 import time
 
 
 class TC:
     def __init__(self):
-        self._tm = tm
+        self._tm = None
         self._bProblem = 0
 
     def setup(self):
@@ -28,7 +29,7 @@ class TC:
         else:
             print("Test not executed. No tear down required.")
 
-    def setTM(self, TM):
+    def setTM(self, tm):
         self._tm = tm
 
     def setProblem(self, value):
@@ -47,7 +48,7 @@ class Reporter:
         print("Reporting the results of Test")
         time.sleep(1)
 
-    def setTM(self, TM):
+    def setTM(self, tm):
         self._tm = tm
 
 
@@ -67,7 +68,7 @@ class DB:
         print("Updating the test results in Database")
         time.sleep(1)
 
-    def setTM(self, TM):
+    def setTM(self, tm):
         self._tm = tm
 
 
@@ -91,7 +92,7 @@ class TestManager:
 
     def publishReport(self):
         self._db.update()
-        rvalue = self._reporter.report()
+        self._reporter.report()
 
     def setTC(self, tc):
         self._tc = tc


### PR DESCRIPTION
First of all, I really enjoyed reading through these patterns today. Thanks for compiling this! The mediator example struck me as a little weak compared to the others in terms of code quality. Here's my proposed fixes to what struck me as the most egregious offenses:

1) Fixed several methods whose parameters were not being used (setTm in
TC, Reporter, and DB), and places where class members were being
assigned the value of global variables.
2) Moved an import to the top of the file, as suggested in pep8
(http://www.python.org/dev/peps/pep-0008/#imports).
3) Removed an unused local variable in TestManager's publishReport
method.
