### PR TITLE
Updated print function's arguments in borg.py.

### DIFF
--- a/borg.py
+++ b/borg.py
@@ -18,19 +18,19 @@ if __name__ == '__main__':
     rm1.state = 'Idle'
     rm2.state = 'Running'
 
-    print('rm1:', rm1)
-    print('rm2:', rm2)
+    print('rm1: {0}'.format(rm1))
+    print('rm2: {0}'.format(rm2))
 
     rm2.state = 'Zombie'
 
-    print('rm1:', rm1)
-    print('rm2:', rm2)
+    print('rm1: {0}'.format(rm1))
+    print('rm2: {0}'.format(rm2))
 
-    print('rm1 id:', id(rm1))
-    print('rm2 id:', id(rm2))
+    print('rm1 id: {0}'.format(id(rm1)))
+    print('rm2 id: {0}'.format(id(rm2)))
 
     rm3 = YourBorg()
 
-    print('rm1:', rm1)
-    print('rm2:', rm2)
-    print('rm3:', rm3)
+    print('rm1: {0}'.format(rm1))
+    print('rm2: {0}'.format(rm2))
+    print('rm3: {0}'.format(rm3))


### PR DESCRIPTION
@faif, Thanks for your devotion about this great python stuff.

BTW, regarding borg.py, I found the print function works as expected in python 3 environment. But it seems that it does not in python 2 environment.

Python 3:

```
pyvers@www1021uh:~/sandbox_3.0.1$ python --version
Python 3.0.1
pyvers@www1021uh:~/sandbox_3.0.1$ python ../borg.py 
rm1: Running
rm2: Running
rm1: Zombie
rm2: Zombie
rm1 id: 139692613715664
rm2 id: 139692613715728
rm1: Zombie
rm2: Zombie
rm3: Zombie
pyvers@www1021uh:~/sandbox_3.0.1$ 
```

Python 2:

```
pyvers@www1021uh:~/sandbox_2.7.5$ python --version
Python 2.7.5
pyvers@www1021uh:~/sandbox_2.7.5$ python ../borg.py
('rm1:', <__main__.Borg instance at 0x1a620e0>)
('rm2:', <__main__.Borg instance at 0x1a62128>)
('rm1:', <__main__.Borg instance at 0x1a620e0>)
('rm2:', <__main__.Borg instance at 0x1a62128>)
('rm1 id:', 27664608)
('rm2 id:', 27664680)
('rm1:', <__main__.Borg instance at 0x1a620e0>)
('rm2:', <__main__.Borg instance at 0x1a62128>)
('rm3:', <__main__.YourBorg instance at 0x1a62170>)
pyvers@www1021uh:~/sandbox_2.7.5$
```

This is because the argument of print function is parsed as tuple in python 2 environment.

So I changed the argument of print function using `str.format()`. This works as expected in both  environments, python 2 and 3. (And I think this is proper way to handle string formatting in python 3 environment, as described like here; http://docs.python.org/3.2/tutorial/inputoutput.html#old-string-formatting )

Python 3:

```
pyvers@www1021uh:~/sandbox_3.0.1$ python --version
Python 3.0.1
pyvers@www1021uh:~/sandbox_3.0.1$ python ../borg.py 
rm1: Running
rm2: Running
rm1: Zombie
rm2: Zombie
rm1 id: 139889706944208
rm2 id: 139889706944272
rm1: Zombie
rm2: Zombie
rm3: Zombie
pyvers@www1021uh:~/sandbox_3.0.1$ 
```

Python 2:

```
pyvers@www1021uh:~/sandbox_2.7.5$ python --version
Python 2.7.5
pyvers@www1021uh:~/sandbox_2.7.5$ python ../borg.py
rm1: Running
rm2: Running
rm1: Zombie
rm2: Zombie
rm1 id: 17121504
rm2 id: 17121576
rm1: Zombie
rm2: Zombie
rm3: Zombie
pyvers@www1021uh:~/sandbox_2.7.5$ 
```

It is much appreciated if you would take a look at this pull request.

Thanks.
