### PR TITLE
chain improvement

### DIFF
--- a/chain.py
+++ b/chain.py
@@ -12,7 +12,7 @@ class Handler:
     def successor(self, successor):
         self._successor = successor
 
-    def handler(self, request):
+    def handle(self, request):
         raise NotImplementedError('Must provide implementation in subclass.')
 
 class ConcreteHandler1(Handler):


### PR DESCRIPTION
- more obvious that `handle` is abstract method in base Handler class
- end-of-chain check in concrete handler classes (so ordering in chain can be changed without changing handler method implementations)
