### PR TITLE
correct decorator pattern

### DIFF
--- a/decorator.py
+++ b/decorator.py
@@ -1,31 +1,40 @@
-"""https://docs.python.org/2/library/functools.html#functools.wraps"""
-"""https://stackoverflow.com/questions/739654/how-can-i-make-a-chain-of-function-decorators-in-python/739665#739665"""
+"""https://en.wikipedia.org/wiki/Decorator_pattern"""
+"""In object-oriented programming, the decorator pattern (also known as Wrapper, 
+   an alternative naming shared with the Adapter pattern) is a design pattern that 
+   allows behavior to be added to an individual object, either statically or dynamically, 
+   without affecting the behavior of other objects from the same class."""
+"""Despite the name, Python decorators are not an implementation of the decorator pattern. 
+   The decorator pattern is a design pattern used in statically typed object-oriented 
+   programming languages to allow functionality to be added to objects at run time; 
+   Python decorators add functionality to functions and methods at definition time, 
+   and thus are a higher-level construct than decorator-pattern classes. The decorator 
+   pattern itself is trivially implementable in Python, because the language is duck typed, 
+   and so is not usually considered as such."""
 
-from functools import wraps
-
-
-def makebold(fn):
-    @wraps(fn)
-    def wrapped():
-        return "<b>" + fn() + "</b>"
-    return wrapped
-
-
-def makeitalic(fn):
-    @wraps(fn)
-    def wrapped():
-        return "<i>" + fn() + "</i>"
-    return wrapped
-
-
-@makebold
-@makeitalic
-def hello():
-    """a decorated hello world"""
-    return "hello world"
-
-if __name__ == '__main__':
-    print('result:{}   name:{}   doc:{}'.format(hello(), hello.__name__, hello.__doc__))
-
-### OUTPUT ###
-# result:<b><i>hello world</i></b>   name:hello   doc:a decorated hello world
+from abc import ABCMeta, abstractmethod
+ 
+class IOperator(metaclass=ABCMeta):
+ 
+    @abstractmethod
+    def operator(self):
+        pass
+ 
+ 
+class Component(IOperator):
+    """Base component"""
+    def operator(self):
+        return 10.0
+ 
+ 
+class Wrapper(IOperator):
+    """Decorator"""
+    def __init__(self, obj):
+        self.obj = obj
+ 
+    def operator(self):
+        return self.obj.operator() + 5.0
+ 
+ 
+comp = Component()
+comp = Wrapper(comp)
+print(comp.operator())  # 15.0


### PR DESCRIPTION
Hello! You've used a decorator statement in example of decorator pattern, but it's wrong, because decorator(pattern) must be based on object-oriented programming. Decorator must be able to be added at runtime.