### PR TITLE
add __future__ print_function

### DIFF
--- a/iterator.py
+++ b/iterator.py
@@ -5,6 +5,8 @@
 
 Implementation of the iterator pattern with a generator"""
 
+from __future__ import print_function
+
 
 def count_to(count):
     """Counts by word numbers, up to a maximum of five"""


### PR DESCRIPTION
print(number, end=' ') won't work in python 2.x, this patch make it work.
Test passed under python 2.7.9, python 2.6.6 and python 3 (ideone.com used).