### PR TITLE
Implementing registry pattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Current Patterns:
 | [prototype](prototype.py) | use a factory and clones of a prototype for new instances (if instantiation is expensive) |
 | [proxy](proxy.py) | an object funnels operations to something else |
 | [publish_subscribe](publish_subscribe.py) | a source syndicates events/data to 0+ registered listeners |
+| [registry](registry.py) | keeping track of all subclasses of a given class |
 | [specification](specification.py) |  business rules can be recombined by chaining the business rules together using boolean logic |
 | [state](state.py) | logic is org'd into a discrete number of potential states and the next state that can be transitioned to |
 | [strategy](strategy.py) | selectable operations over the same data |

--- a/registry.py
+++ b/registry.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+
+class RegistryHolder(type):
+
+    REGISTRY = {}
+
+    def __new__(cls, name, bases, attrs):
+        new_cls = type.__new__(cls, name, bases, attrs)
+        """
+            Here the name of the class is used as key but it could be any class
+            parameter.
+        """
+        cls.REGISTRY[new_cls.__name__] = new_cls
+        return new_cls
+
+    @classmethod
+    def get_registry(cls):
+        return dict(cls.REGISTRY)
+
+
+class BaseRegisteredClass(metaclass=RegistryHolder):
+    """
+        Any class that will inherits from BaseRegisteredClass will be included
+        inside the dict RegistryHolder.REGISTRY, the key being the name of the
+        class and the associated value, the class itself.
+    """
+    pass
+
+if __name__ == "__main__":
+    print("Before subclassing: ")
+    for k in RegistryHolder.REGISTRY:
+        print(k)
+
+    class ClassRegistree(BaseRegisteredClass):
+
+        def __init__(self, *args, **kwargs):
+            pass
+    print("After subclassing: ")
+    for k in RegistryHolder.REGISTRY:
+        print(k)
+
+### OUTPUT ###
+# Before subclassing: 
+# BaseRegisteredClass
+# After subclassing: 
+# BaseRegisteredClass
+# ClassRegistree


### PR DESCRIPTION
Such pattern can allow for keeping track of all subclasses for a given parent using `metaclass`.