### PR TITLE
deepcopy logic inverted

### DIFF
--- a/memento.py
+++ b/memento.py
@@ -7,7 +7,7 @@ from copy import copy, deepcopy
 
 
 def memento(obj, deep=False):
-    state = copy(obj.__dict__) if deep else deepcopy(obj.__dict__)
+    state = deepcopy(obj.__dict__) if deep else copy(obj.__dict__)
 
     def restore():
         obj.__dict__.clear()


### PR DESCRIPTION
According to the orignal ActiveState recipe, deepcopy() should be called when 'deep' parameter is True.

Relevant orignal snippet: 

```(copy.copy, copy.deepcopy)[bool(deep)](obj.__dict__)```