### PR TITLE
Explicitly promise functionality in the abstract interface

### DIFF
--- a/builder.py
+++ b/builder.py
@@ -31,6 +31,11 @@ class Builder(object):
     def new_building(self):
         self.building = Building()
 
+    def build_floor(self):
+        raise NotImplemented
+
+    def build_size(self):
+        raise NotImplemented
 
 # Concrete Builder
 class BuilderHouse(Builder):


### PR DESCRIPTION
Summary: Explicitly promise functions implemented by concrete builders by declaring them in the abstract interface.

Reason: Clients should not need to know about extra functionality of concrete builders beyond what is declared in the abstract interface. It is the abstract interface's job to tell clients the interface its concrete implementations will serve.