### PR TITLE
Modification for proxy example

### DIFF
--- a/proxy.py
+++ b/proxy.py
@@ -5,9 +5,6 @@ import time
 
 
 class SalesManager:
-    def work(self):
-        print("Sales Manager working...")
-
     def talk(self):
         print("Sales Manager ready to talk")
 
@@ -17,7 +14,7 @@ class Proxy:
         self.busy = 'No'
         self.sales = None
 
-    def work(self):
+    def talk(self):
         print("Proxy checking for Sales Manager availability")
         if self.busy == 'No':
             self.sales = SalesManager()
@@ -29,10 +26,7 @@ class Proxy:
 
 
 class NoTalkProxy(Proxy):
-    def __init__(self):
-        Proxy.__init__(self)
-
-    def work(self):
+    def talk(self):
         print("Proxy checking for Sales Manager availability")
         time.sleep(2)
         print("This Sales Manager will not talk to you whether he/she is busy or not")
@@ -40,13 +34,13 @@ class NoTalkProxy(Proxy):
 
 if __name__ == '__main__':
     p = Proxy()
-    p.work()
+    p.talk()
     p.busy = 'Yes'
-    p.work()
+    p.talk()
     p = NoTalkProxy()
-    p.work()
+    p.talk()
     p.busy = 'Yes'
-    p.work()
+    p.talk()
 
 ### OUTPUT ###
 # Proxy checking for Sales Manager availability


### PR DESCRIPTION
Hi!

Accordingly to diagram in wikipedia for proxy pattern: ![proxy pattern](https://upload.wikimedia.org/wikipedia/commons/7/75/Proxy_pattern_diagram.svg)

From interface point of view, proxy method delegate similar functionality to subject. I think, it would be clearer, if example will not call `talk` method on real subject in `work` method in proxy. It would be closer to canonical proxy example.