### PR TITLE
lazy evaluation: use descriptors

### DIFF
--- a/lazy_evaluation.py
+++ b/lazy_evaluation.py
@@ -5,20 +5,35 @@
 Lazily-evaluated property pattern in Python.
 
 https://en.wikipedia.org/wiki/Lazy_evaluation
-http://stevenloria.com/lazy-evaluated-properties-in-python/
+
+References:
+bottle
+https://github.com/bottlepy/bottle/blob/cafc15419cbb4a6cb748e6ecdccf92893bb25ce5/bottle.py#L270
+django
+https://github.com/django/django/blob/ffd18732f3ee9e6f0374aff9ccf350d85187fac2/django/utils/functional.py#L19
+pip
+https://github.com/pypa/pip/blob/cb75cca785629e15efb46c35903827b3eae13481/pip/utils/__init__.py#L821
+pyramimd
+https://github.com/Pylons/pyramid/blob/7909e9503cdfc6f6e84d2c7ace1d3c03ca1d8b73/pyramid/decorator.py#L4
+werkzeug
+https://github.com/pallets/werkzeug/blob/5a2bf35441006d832ab1ed5a31963cbc366c99ac/werkzeug/utils.py#L35
 """
 
 
-def lazy_property(fn):
-    """Decorator that makes a property lazy-evaluated."""
-    attr_name = '_lazy_' + fn.__name__
+import functools
 
-    @property
-    def _lazy_property(self):
-        if not hasattr(self, attr_name):
-            setattr(self, attr_name, fn(self))
-        return getattr(self, attr_name)
-    return _lazy_property
+
+class lazy_property(object):
+    def __init__(self, function):
+        self.function = function
+        functools.update_wrapper(self, function)
+
+    def __get__(self, obj, type_):
+        if obj is None:
+            return self
+        val = self.function(obj)
+        obj.__dict__[self.function.__name__] = val
+        return val
 
 
 class Person(object):


### PR DESCRIPTION
The updated implementation uses a non-data descriptor to achieve the task,
as how it is done in [bottlepy](https://github.com/bottlepy/bottle/blob/cafc15419cbb4a6cb748e6ecdccf92893bb25ce5/bottle.py#L270), [django](https://github.com/django/django/blob/ffd18732f3ee9e6f0374aff9ccf350d85187fac2/django/utils/functional.py#L19), [pyramid](https://github.com/Pylons/pyramid/blob/7909e9503cdfc6f6e84d2c7ace1d3c03ca1d8b73/pyramid/decorator.py#L4) and [pip](https://github.com/pypa/pip/blob/cb75cca785629e15efb46c35903827b3eae13481/pip/utils/__init__.py#L821).

see also: https://gist.github.com/afg984/a2aa7e0ba4e3d908118fa6e4f44f8ac8
which includes a simple comparison & benchmark