### PR TITLE
Remove third party package dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ cache:
 
 install:
   - travis_retry pip install -q coveralls codecov
-  - pip install flake8 six  # eventually worth
+  - pip install flake8  # eventually worth
 
 script:
   # Run tests

--- a/flyweight.py
+++ b/flyweight.py
@@ -5,8 +5,6 @@
 
 import weakref
 
-from six import add_metaclass
-
 
 class FlyweightMeta(type):
 
@@ -67,8 +65,12 @@ class Card(object):
         return "<Card: %s%s>" % (self.value, self.suit)
 
 
-@add_metaclass(FlyweightMeta)
-class Card2(object):
+def with_metaclass(meta, *bases):
+    """ Provide python cross-version metaclass compatibility. """
+    return meta("NewBase", bases, {})
+
+
+class Card2(with_metaclass(FlyweightMeta)):
 
     def __init__(self, *args, **kwargs):
         # print('Init {}: {}'.format(self.__class__, (args, kwargs)))


### PR DESCRIPTION
Remove usage of third party package (six);
Add with_metaclass function to provide cross-version compatibility without six module dependency.

with_metaclass() is a utility class factory function provided to make it easier to develop code for both Python 2 and 3.
It creates a base class with the specified meta class for you, compatible with the version of Python you are running the code on.
This is needed because the syntax to attach a metaclass changed between Python 2 and 3

Resolve issue #117 