### PR TITLE
Existing tests formal purification

### DIFF
--- a/tests/test_abstract_factory.py
+++ b/tests/test_abstract_factory.py
@@ -2,7 +2,10 @@
 # -*- coding: utf-8 -*-
 import sys
 import unittest
-from unittest.mock import patch
+try:
+    from unittest.mock import patch
+except ImportError:
+    from mock import patch
 from creational.abstract_factory import PetShop,\
     Dog, Cat, DogFactory, CatFactory
 

--- a/tests/test_abstract_factory.py
+++ b/tests/test_abstract_factory.py
@@ -1,18 +1,10 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 import sys
+import unittest
+from unittest.mock import patch
 from creational.abstract_factory import PetShop,\
     Dog, Cat, DogFactory, CatFactory
-
-if sys.version_info < (2, 7):
-    import unittest2 as unittest
-else:
-    import unittest
-
-try:
-    from unittest.mock import patch
-except ImportError:
-    from mock import patch
 
 
 class TestPetShop(unittest.TestCase):

--- a/tests/test_abstract_factory.py
+++ b/tests/test_abstract_factory.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-
-from creational.abstract_factory import PetShop, Dog, Cat, DogFactory, CatFactory
 import sys
+from creational.abstract_factory import PetShop,\
+    Dog, Cat, DogFactory, CatFactory
 
 if sys.version_info < (2, 7):
     import unittest2 as unittest
@@ -16,11 +16,11 @@ except ImportError:
 
 
 class TestPetShop(unittest.TestCase):
-    
+
     def test_dog_pet_shop_shall_show_dog_instance(self):
         f = DogFactory()
         with patch.object(f, 'get_pet') as mock_f_get_pet,\
-             patch.object(f, 'get_food') as mock_f_get_food:
+                patch.object(f, 'get_food') as mock_f_get_food:
             ps = PetShop(f)
             ps.show_pet()
             self.assertEqual(mock_f_get_pet.call_count, 1)
@@ -29,7 +29,7 @@ class TestPetShop(unittest.TestCase):
     def test_cat_pet_shop_shall_show_cat_instance(self):
         f = CatFactory()
         with patch.object(f, 'get_pet') as mock_f_get_pet,\
-             patch.object(f, 'get_food') as mock_f_get_food:
+                patch.object(f, 'get_food') as mock_f_get_food:
             ps = PetShop(f)
             ps.show_pet()
             self.assertEqual(mock_f_get_pet.call_count, 1)

--- a/tests/test_abstract_factory.py
+++ b/tests/test_abstract_factory.py
@@ -60,8 +60,3 @@ class TestDog(unittest.TestCase):
 
     def test_dog_shall_be_printable(cls):
         cls.assertEqual(str(cls.d), 'Dog')
-
-
-if __name__ == "__main__":
-    unittest.main()
-

--- a/tests/test_abstract_factory.py
+++ b/tests/test_abstract_factory.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-import sys
 import unittest
 try:
     from unittest.mock import patch


### PR DESCRIPTION
Hope these changes look pretty and straightforward a bit. But I consider to implement similar operations on all existing tests for clarification purposes only.

In addition a lot of kinky misleadings are there and all they would be elaborated into a contemporary manner. Such as:

`    @classmethod                                                                                                                              
    def setUpClass(cls):                                                                                                                      
        cls.c = Cat()`

of cause it is just a _setUp_ method of unittest module.

After these clarification manipulation it might be handy to take a closer look on semantic meaning, or what this particular code snippets should illustrate and what they really do.
