### PR TITLE
Add Support for Python 3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ python:
   - "3.3"
   - "3.4"
   - "3.5"
+  - "3.6"
 # Disabled for now since cause more pain than gain
 #  - "pypy"
 #  - "pypy3"


### PR DESCRIPTION
Python 3.6.0 is the newest major release of the Python language, and it contains many new features and optimizations. Adding it travis CI configuration.