### PR TITLE
Update decorator.py

### DIFF
--- a/structural/decorator.py
+++ b/structural/decorator.py
@@ -13,7 +13,7 @@ class TextTag(object):
         return self._text
 
 
-class BoldWrapper(object):
+class BoldWrapper(TextTag):
     """Wraps a tag in <b>"""
     def __init__(self, wrapped):
         self._wrapped = wrapped
@@ -22,7 +22,7 @@ class BoldWrapper(object):
         return "<b>{}</b>".format(self._wrapped.render())
 
 
-class ItalicWrapper(object):
+class ItalicWrapper(TextTag):
     """Wraps a tag in <i>"""
     def __init__(self, wrapped):
         self._wrapped = wrapped


### PR DESCRIPTION
I would extend the decorator from the base class. The reason is that we still expect an italic bold text to be a text! So we expect the behaviours of the basic TextTag class to exists in the class that is being decorated. Example: If you add the following method to the **TextTag class**, you expect **your decorated objects** still be able to call that method:

```
def say_hello():
    print 'hello I am text!'
```