### PR TITLE
fix graph search find path backtracking

### DIFF
--- a/other/graph_search.py
+++ b/other/graph_search.py
@@ -19,7 +19,7 @@ class GraphSearch:
             return path
         for node in self.graph.get(start, []):
             if node not in path:
-                newpath = self.find_path(node, end, path)
+                newpath = self.find_path(node, end, path[:])
                 if newpath:
                     return newpath
 


### PR DESCRIPTION
`path` will get modified in recursive call if passed by reference. And can be simply fixed by passing a copy of it.