### PR TITLE
Add coveragerc to ignore NotImplementedError's in tests

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,6 @@
+[report]
+exclude_lines =
+    pragma: no cover
+    # Don't complain if tests don't hit defensive assertion code:
+    # See: https://stackoverflow.com/a/9212387/3407256
+    raise NotImplementedError


### PR DESCRIPTION
This will exlcude lines like the following from codecov report:
https://codecov.io/gh/faif/python-patterns/src/master/structural/mvc.py#L12