### PR TITLE
Allow delegator to return delegate's properties

### DIFF
--- a/fundamental/delegation_pattern.py
+++ b/fundamental/delegation_pattern.py
@@ -9,6 +9,7 @@ Author: https://github.com/IuryAlves
 Allows object composition to achieve the same code reuse as inheritance.
 """
 
+
 class Delegator(object):
     """
     >>> delegator = Delegator(Delegate())

--- a/fundamental/delegation_pattern.py
+++ b/fundamental/delegation_pattern.py
@@ -9,30 +9,41 @@ Author: https://github.com/IuryAlves
 Allows object composition to achieve the same code reuse as inheritance.
 """
 
-
 class Delegator(object):
     """
     >>> delegator = Delegator(Delegate())
+    >>> delegator.p1
+    123
+    >>> delegator.p2
+    Traceback (most recent call last):
+    ...
+    AttributeError: 'Delegate' object has no attribute 'p2'
     >>> delegator.do_something("nothing")
     'Doing nothing'
     >>> delegator.do_anything()
-
+    Traceback (most recent call last):
+    ...
+    AttributeError: 'Delegate' object has no attribute 'do_anything'
     """
 
     def __init__(self, delegate):
         self.delegate = delegate
 
     def __getattr__(self, name):
-        def wrapper(*args, **kwargs):
-            if hasattr(self.delegate, name):
-                attr = getattr(self.delegate, name)
-                if callable(attr):
-                    return attr(*args, **kwargs)
+        attr = getattr(self.delegate, name)
+        
+        if not callable(attr):
+            return attr
 
+        def wrapper(*args, **kwargs):
+            return attr(*args, **kwargs)
         return wrapper
 
 
 class Delegate(object):
+    def __init__(self):
+        self.p1 = 123
+
     def do_something(self, something):
         return "Doing %s" % something
 


### PR DESCRIPTION
The current code does not allow the delegator to return the value of properties of the delegate but can only call its methods. Moreover if the method does not exist then `None` is returned rather than raising an exception.
This PR is for fixing the above.