### PR TITLE
Remove coveralls

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ cache:
   - pip
 
 install:
-  - travis_retry pip install -q coveralls codecov six
+  - travis_retry pip install -q codecov six
   - pip install flake8  # eventually worth
 
 script:
@@ -28,5 +28,4 @@ script:
   - flake8 *py
 
 after_success:
-  - coveralls
   - codecov


### PR DESCRIPTION
1. `coveralls` and `codecov` do basically the same
2. here is travis output for several (possibly all) latest PRs
```
$ coveralls
Submitting coverage to coveralls.io...
Coverage submitted!
Couldn't find a repository matching this job.
Traceback (most recent call last):
  File "/home/travis/virtualenv/python3.6.3/bin/coveralls", line 11, in <module>
    sys.exit(main())
  File "/home/travis/virtualenv/python3.6.3/lib/python3.6/site-packages/coveralls/cli.py", line 80, in main
    log.info(result['url'])
KeyError: 'url'
```