### PR TITLE
Move from nosetests to pytest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,12 +17,13 @@ cache:
   - pip
 
 install:
-  - travis_retry pip install -q codecov six
-  - pip install flake8  # eventually worth
+  - travis_retry pip install -q codecov
+  - pip install flake8
+  - pip install -r requirements-dev.txt
 
 script:
-  # Run tests
-  - PYTHONPATH=. nosetests -s -v --with-doctest --with-cov --cover-package . --logging-level=INFO -v .
+  - pytest --doctest-modules behavioral/ creational/ dft/ fundamental/ other/ structural/  # exclude tests/
+  - pytest -s -vv --cov=. --log-level=INFO tests/
   # Actually run all the scripts, contributing to coverage
   - PYTHONPATH=. ./run_all.sh
   - flake8 *py

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,2 @@
+pytest~=4.1
+pytest-cov~=2.6


### PR DESCRIPTION
fixes #259 

**Split doctests from unittests**
Different types of tests belong to different CI stages.
Also, in this particular repository doctests can also be tests for script OUTPUTS (I will make a separate PR to show what I mean).

**Separate `requirements-dev.txt`**
It is very convenient (for local development) to be able to setup deps and pre-commit hooks.
In case of travis-ci packages already present in container (e.g. pytest) will be skipped.
As for `flake8` and linting - I plan to address that in separate PR.