### PR TITLE
Travis config: test with 3.7, drop 3.4, 3.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,13 @@
 # vim ft=yaml
-# travis-ci.org definition for python-patterns build
+dist: xenial
 language: python
 
 sudo: false
 
 python:
   - "2.7"
-  - "3.4"
-  - "3.5"
   - "3.6"
+  - "3.7"
 
 cache:
   - pip

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,3 +3,4 @@ pytest~=4.1
 pytest-cov~=2.6
 flake8~=3.6
 codecov~=2.0
+mock~=2.0


### PR DESCRIPTION
Default travis env is Ubuntu Trusty 14.04 which doesn't have 3.7

I propose to 
- move from Trusty to Xenial (16.04)
- add support for 3.7
- drop support for 3.4, 3.5
https://docs.travis-ci.com/user/reference/xenial/#python-support