### PR TITLE
Doctests all around

### DIFF
--- a/patterns/behavioral/memento.py
+++ b/patterns/behavioral/memento.py
@@ -128,7 +128,7 @@ def main():
     -> doing stuff failed!
     Traceback (most recent call last):
     ...
-    TypeError: can only concatenate str (not "int") to str
+    TypeError: ...str...int...
 
     >>> print(num_obj)
     <NumObj: 2>

--- a/patterns/behavioral/memento.py
+++ b/patterns/behavioral/memento.py
@@ -82,67 +82,59 @@ class NumObj(object):
 
 
 def main():
-    num_obj = NumObj(-1)
-    print(num_obj)
+    """
+    >>> num_obj = NumObj(-1)
+    >>> print(num_obj)
+    <NumObj: -1>
 
-    a_transaction = Transaction(True, num_obj)
-    try:
-        for i in range(3):
-            num_obj.increment()
-            print(num_obj)
-        a_transaction.commit()
-        print('-- committed')
+    >>> a_transaction = Transaction(True, num_obj)
 
-        for i in range(3):
-            num_obj.increment()
-            print(num_obj)
-        num_obj.value += 'x'  # will fail
-        print(num_obj)
-    except Exception:
-        a_transaction.rollback()
-        print('-- rolled back')
-    print(num_obj)
+    >>> try:
+    ...    for i in range(3):
+    ...        num_obj.increment()
+    ...        print(num_obj)
+    ...    a_transaction.commit()
+    ...    print('-- committed')
+    ...    for i in range(3):
+    ...        num_obj.increment()
+    ...        print(num_obj)
+    ...    num_obj.value += 'x'  # will fail
+    ...    print(num_obj)
+    ... except Exception:
+    ...    a_transaction.rollback()
+    ...    print('-- rolled back')
+    <NumObj: 0>
+    <NumObj: 1>
+    <NumObj: 2>
+    -- committed
+    <NumObj: 3>
+    <NumObj: 4>
+    <NumObj: 5>
+    -- rolled back
 
-    print('-- now doing stuff ...')
-    try:
-        num_obj.do_stuff()
-    except Exception:
-        print('-> doing stuff failed!')
-        import sys
-        import traceback
+    >>> print(num_obj)
+    <NumObj: 2>
 
-        traceback.print_exc(file=sys.stdout)
-    print(num_obj)
+    >>> print('-- now doing stuff ...')
+    -- now doing stuff ...
+
+    >>> try:
+    ...    num_obj.do_stuff()
+    ... except Exception:
+    ...    print('-> doing stuff failed!')
+    ...    import sys
+    ...    import traceback
+    ...    traceback.print_exc(file=sys.stdout)
+    -> doing stuff failed!
+    Traceback (most recent call last):
+    ...
+    TypeError: can only concatenate str (not "int") to str
+
+    >>> print(num_obj)
+    <NumObj: 2>
+    """
 
 
-if __name__ == '__main__':
-    main()
-
-
-OUTPUT = """
-<NumObj: -1>
-<NumObj: 0>
-<NumObj: 1>
-<NumObj: 2>
--- committed
-<NumObj: 3>
-<NumObj: 4>
-<NumObj: 5>
--- rolled back
-<NumObj: 2>
--- now doing stuff ...
--> doing stuff failed!
-Traceback (most recent call last):
-  File "patterns/behavioral/memento.py", line 108, in main
-    num_obj.do_stuff()
-  File "patterns/behavioral/memento.py", line 63, in transaction
-    raise e
-  File "patterns/behavioral/memento.py", line 60, in transaction
-    return self.method(obj, *args, **kwargs)
-  File "patterns/behavioral/memento.py", line 81, in do_stuff
-    self.increment()  # <- will fail and rollback
-  File "patterns/behavioral/memento.py", line 76, in increment
-    self.value += 1
-TypeError: can only concatenate str (not "int") to str
-<NumObj: 2>
-"""
+if __name__ == "__main__":
+    import doctest
+    doctest.testmod(optionflags=doctest.ELLIPSIS)

--- a/patterns/behavioral/template.py
+++ b/patterns/behavioral/template.py
@@ -69,6 +69,7 @@ def main():
     `csv` was processed
     """
 
+
 if __name__ == "__main__":
     import doctest
     doctest.testmod()

--- a/patterns/behavioral/template.py
+++ b/patterns/behavioral/template.py
@@ -50,29 +50,25 @@ def template_function(getter, converter=False, to_save=False):
 
 
 def main():
-    template_function(get_text, to_save=True)
-    print("-" * 30)
-    template_function(get_pdf, converter=convert_to_text)
-    print("-" * 30)
-    template_function(get_csv, to_save=True)
+    """
+    >>> template_function(get_text, to_save=True)
+    Got `plain-text`
+    Skip conversion
+    [SAVE]
+    `plain-text` was processed
 
+    >>> template_function(get_pdf, converter=convert_to_text)
+    Got `pdf`
+    [CONVERT]
+    `pdf as text` was processed
+
+    >>> template_function(get_csv, to_save=True)
+    Got `csv`
+    Skip conversion
+    [SAVE]
+    `csv` was processed
+    """
 
 if __name__ == "__main__":
-    main()
-
-
-OUTPUT = """
-Got `plain-text`
-Skip conversion
-[SAVE]
-`plain-text` was processed
-------------------------------
-Got `pdf`
-[CONVERT]
-`pdf as text` was processed
-------------------------------
-Got `csv`
-Skip conversion
-[SAVE]
-`csv` was processed
-"""
+    import doctest
+    doctest.testmod()

--- a/patterns/structural/adapter.py
+++ b/patterns/structural/adapter.py
@@ -70,28 +70,6 @@ class Adapter(object):
     Usage:
     dog = Dog()
     dog = Adapter(dog, make_noise=dog.bark)
-
-    >>> objects = []
-    >>> dog = Dog()
-    >>> print(dog.__dict__)
-    {'name': 'Dog'}
-    >>> objects.append(Adapter(dog, make_noise=dog.bark))
-    >>> print(objects[0].original_dict())
-    {'name': 'Dog'}
-    >>> cat = Cat()
-    >>> objects.append(Adapter(cat, make_noise=cat.meow))
-    >>> human = Human()
-    >>> objects.append(Adapter(human, make_noise=human.speak))
-    >>> car = Car()
-    >>> car_noise = lambda: car.make_noise(3)
-    >>> objects.append(Adapter(car, make_noise=car_noise))
-
-    >>> for obj in objects:
-    ...     print('A {} goes {}'.format(obj.name, obj.make_noise()))
-    A Dog goes woof!
-    A Cat goes meow!
-    A Human goes 'hello'
-    A Car goes vroom!!!
     """
 
     def __init__(self, obj, **adapted_methods):
@@ -109,32 +87,36 @@ class Adapter(object):
 
 
 def main():
+    """
+    >>> objects = []
+    >>> dog = Dog()
+    >>> print(dog.__dict__)
+    {'name': 'Dog'}
 
-    objects = []
-    dog = Dog()
-    print(dog.__dict__)
-    objects.append(Adapter(dog, make_noise=dog.bark))
-    print(objects[0].__dict__)
-    print(objects[0].original_dict())
-    cat = Cat()
-    objects.append(Adapter(cat, make_noise=cat.meow))
-    human = Human()
-    objects.append(Adapter(human, make_noise=human.speak))
-    car = Car()
-    objects.append(Adapter(car, make_noise=lambda: car.make_noise(3)))
+    >>> objects.append(Adapter(dog, make_noise=dog.bark))
 
-    for obj in objects:
-        print("A {0} goes {1}".format(obj.name, obj.make_noise()))
+    >>> objects[0].__dict__['obj'], objects[0].__dict__['make_noise']
+    (<...Dog object at 0x...>, <bound method Dog.bark of <...Dog object at 0x...>>)
+
+    >>> print(objects[0].original_dict())
+    {'name': 'Dog'}
+
+    >>> cat = Cat()
+    >>> objects.append(Adapter(cat, make_noise=cat.meow))
+    >>> human = Human()
+    >>> objects.append(Adapter(human, make_noise=human.speak))
+    >>> car = Car()
+    >>> objects.append(Adapter(car, make_noise=lambda: car.make_noise(3)))
+
+    >>> for obj in objects:
+    ...    print("A {0} goes {1}".format(obj.name, obj.make_noise()))
+    A Dog goes woof!
+    A Cat goes meow!
+    A Human goes 'hello'
+    A Car goes vroom!!!
+    """
 
 
 if __name__ == "__main__":
-    main()
-
-### OUTPUT ###
-# {'name': 'Dog'}
-# {'make_noise': <bound method Dog.bark of <__main__.Dog object at 0x7f631ba3fb00>>, 'obj': <__main__.Dog object at 0x7f631ba3fb00>}    # noqa flake8
-# {'name': 'Dog'}
-# A Dog goes woof!
-# A Cat goes meow!
-# A Human goes 'hello'
-# A Car goes vroom!!!
+    import doctest
+    doctest.testmod(optionflags=doctest.ELLIPSIS)

--- a/tests/test_outputs.py
+++ b/tests/test_outputs.py
@@ -30,8 +30,6 @@ from patterns.behavioral.state import main as state_main
 from patterns.behavioral.state import OUTPUT as state_output
 from patterns.behavioral.strategy import main as strategy_main
 from patterns.behavioral.strategy import OUTPUT as strategy_output
-from patterns.behavioral.template import main as template_main
-from patterns.behavioral.template import OUTPUT as template_output
 from patterns.behavioral.visitor import main as visitor_main
 from patterns.behavioral.visitor import OUTPUT as visitor_output
 
@@ -50,7 +48,6 @@ from patterns.behavioral.visitor import OUTPUT as visitor_output
     (specification_main, specification_output),
     (state_main, state_output),
     (strategy_main, strategy_output),
-    (template_main, template_output),
     (visitor_main, visitor_output),
 ])
 def test_output(main, output):


### PR DESCRIPTION
This PR is for discussion purposes but it contains changes which are ready to merge.
Please review from easiest to longest: Template, Adapter, Memento

**Template**: not much changed (I expect it to be the common case for other examples)

**Adapter**: I don't know why the diff is like that, it shows many functions I didn't touch. My advice for this particular commit is to compare before/after files by eye.
Because the important change is in one line:
before
```python
# in main()
print(objects[0].__dict__)
# output
{'make_noise': <bound method Dog.bark of <__main__.Dog object at 0x7f631ba3fb00>>, 'obj': <__main__.Dog object at 0x7f631ba3fb00>}    # noqa flake8
```

after
```python
 >>> objects[0].__dict__['obj'], objects[0].__dict__['make_noise']
(<...Dog object at 0x...>, <bound method Dog.bark of <...Dog object at 0x...>>)
```

"..." dots represent module and object memory address.


**Memento**
most of traceback is intentionally hidden under "..."


I will also describe some transition subtleties in #258 to discuss further

@faif please let me know if I should proceed with other examples.
Although this PR is ready as is.