### PR TITLE
Replace TL;DR80 -> TL;DR

### DIFF
--- a/patterns/behavioral/chain_of_responsibility__py2.py
+++ b/patterns/behavioral/chain_of_responsibility__py2.py
@@ -17,7 +17,7 @@ Request receiver in simple form keeps a reference to a single successor.
 As a variation some receivers may be capable of sending requests out
 in several directions, forming a `tree of responsibility`.
 
-*TL;DR80
+*TL;DR
 Allow a request to pass down a chain of receivers until it is handled.
 """
 

--- a/patterns/behavioral/chain_of_responsibility__py3.py
+++ b/patterns/behavioral/chain_of_responsibility__py3.py
@@ -17,7 +17,7 @@ Request receiver in simple form keeps a reference to a single successor.
 As a variation some receivers may be capable of sending requests out
 in several directions, forming a `tree of responsibility`.
 
-*TL;DR80
+*TL;DR
 Allow a request to pass down a chain of receivers until it is handled.
 """
 

--- a/patterns/behavioral/command.py
+++ b/patterns/behavioral/command.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 """
-*TL;DR80
+*TL;DR
 Encapsulates all information needed to perform an action or trigger an event.
 
 *Examples in Python ecosystem:

--- a/patterns/behavioral/iterator.py
+++ b/patterns/behavioral/iterator.py
@@ -5,7 +5,7 @@
 http://ginstrom.com/scribbles/2007/10/08/design-patterns-python-style/
 Implementation of the iterator pattern with a generator
 
-*TL;DR80
+*TL;DR
 Traverses a container and accesses the container's elements.
 """
 

--- a/patterns/behavioral/mediator.py
+++ b/patterns/behavioral/mediator.py
@@ -7,7 +7,7 @@ https://www.djangospin.com/design-patterns-python/mediator/
 Objects in a system communicate through a Mediator instead of directly with each other.
 This reduces the dependencies between communicating objects, thereby reducing coupling.
 
-*TL;DR80
+*TL;DR
 Encapsulates how a set of objects interact.
 """
 

--- a/patterns/behavioral/memento.py
+++ b/patterns/behavioral/memento.py
@@ -4,7 +4,7 @@
 """
 http://code.activestate.com/recipes/413838-memento-closure/
 
-*TL;DR80
+*TL;DR
 Provides the ability to restore an object to its previous state.
 """
 

--- a/patterns/behavioral/observer.py
+++ b/patterns/behavioral/observer.py
@@ -4,7 +4,7 @@
 """
 http://code.activestate.com/recipes/131499-observer-pattern/
 
-*TL;DR80
+*TL;DR
 Maintains a list of dependents and notifies them of any state changes.
 
 *Examples in Python ecosystem:

--- a/patterns/behavioral/specification.py
+++ b/patterns/behavioral/specification.py
@@ -4,7 +4,7 @@
 """
 @author: Gordeev Andrey <gordeev.and.and@gmail.com>
 
-*TL;DR80
+*TL;DR
 Provides recombination business logic by chaining together using boolean logic.
 """
 

--- a/patterns/behavioral/state.py
+++ b/patterns/behavioral/state.py
@@ -6,7 +6,7 @@ Implementation of the state pattern
 
 http://ginstrom.com/scribbles/2007/10/08/design-patterns-python-style/
 
-*TL;DR80
+*TL;DR
 Implements state as a derived class of the state pattern interface.
 Implements state transitions by invoking methods from the pattern's superclass.
 """

--- a/patterns/behavioral/strategy.py
+++ b/patterns/behavioral/strategy.py
@@ -6,7 +6,7 @@
 Define a family of algorithms, encapsulate each one, and make them interchangeable.
 Strategy lets the algorithm vary independently from clients that use it.
 
-*TL;DR80
+*TL;DR
 Enables selecting an algorithm at runtime.
 """
 

--- a/patterns/behavioral/template.py
+++ b/patterns/behavioral/template.py
@@ -4,7 +4,7 @@
 """
 An example of the Template pattern in Python
 
-*TL;DR80
+*TL;DR
 Defines the skeleton of a base algorithm, deferring definition of exact
 steps to subclasses.
 

--- a/patterns/behavioral/visitor.py
+++ b/patterns/behavioral/visitor.py
@@ -4,7 +4,7 @@
 """
 http://peter-hoffmann.com/2010/extrinsic-visitor-pattern-python-inheritance.html
 
-*TL;DR80
+*TL;DR
 Separates an algorithm from an object structure on which it operates.
 
 An interesting recipe could be found in

--- a/patterns/creational/abstract_factory.py
+++ b/patterns/creational/abstract_factory.py
@@ -29,7 +29,7 @@ based on my own criteria, dogs over cats.
 https://sourcemaking.com/design_patterns/abstract_factory
 http://ginstrom.com/scribbles/2007/10/08/design-patterns-python-style/
 
-*TL;DR80
+*TL;DR
 Provides a way to encapsulate a group of individual factories.
 """
 

--- a/patterns/creational/borg.py
+++ b/patterns/creational/borg.py
@@ -36,7 +36,7 @@ https://github.com/onetwopunch/pythonDbTemplate/blob/master/database.py
 *References:
 https://fkromer.github.io/python-pattern-references/design/#singleton
 
-*TL;DR80
+*TL;DR
 Provides singleton-like behavior sharing state between instances.
 """
 

--- a/patterns/creational/builder.py
+++ b/patterns/creational/builder.py
@@ -30,7 +30,7 @@ this kind of arrangement is also included.
 *References:
 https://sourcemaking.com/design_patterns/builder
 
-*TL;DR80
+*TL;DR
 Decouples the creation of a complex object and its representation.
 """
 

--- a/patterns/creational/factory.py
+++ b/patterns/creational/factory.py
@@ -24,7 +24,7 @@ purposes.
 *References:
 http://ginstrom.com/scribbles/2007/10/08/design-patterns-python-style/
 
-*TL;DR80
+*TL;DR
 Creates objects without having to specify the exact class.
 """
 

--- a/patterns/creational/lazy_evaluation.py
+++ b/patterns/creational/lazy_evaluation.py
@@ -18,7 +18,7 @@ https://github.com/Pylons/pyramid/blob/7909e9503cdfc6f6e84d2c7ace1d3c03ca1d8b73/
 werkzeug
 https://github.com/pallets/werkzeug/blob/5a2bf35441006d832ab1ed5a31963cbc366c99ac/werkzeug/utils.py#L35
 
-*TL;DR80
+*TL;DR
 Delays the eval of an expr until its value is needed and avoids repeated evals.
 """
 

--- a/patterns/creational/pool.py
+++ b/patterns/creational/pool.py
@@ -27,7 +27,7 @@ function is deleted (by the GC) and the object is returned.
 http://stackoverflow.com/questions/1514120/python-implementation-of-the-object-pool-design-pattern
 https://sourcemaking.com/design_patterns/object_pool
 
-*TL;DR80
+*TL;DR
 Stores a set of initialized objects kept ready to use.
 """
 

--- a/patterns/creational/prototype.py
+++ b/patterns/creational/prototype.py
@@ -20,7 +20,7 @@ instance.
 Below provides an example of such Dispatcher, which contains three
 copies of the prototype: 'default', 'objecta' and 'objectb'.
 
-*TL;DR80
+*TL;DR
 Creates new object instances by cloning prototype.
 """
 

--- a/patterns/fundamental/delegation_pattern.py
+++ b/patterns/fundamental/delegation_pattern.py
@@ -5,7 +5,7 @@
 Reference: https://en.wikipedia.org/wiki/Delegation_pattern
 Author: https://github.com/IuryAlves
 
-*TL;DR80
+*TL;DR
 Allows object composition to achieve the same code reuse as inheritance.
 """
 

--- a/patterns/structural/3-tier.py
+++ b/patterns/structural/3-tier.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 """
-*TL;DR80
+*TL;DR
 Separates presentation, application processing, and data management functions.
 """
 

--- a/patterns/structural/adapter.py
+++ b/patterns/structural/adapter.py
@@ -27,7 +27,7 @@ http://ginstrom.com/scribbles/2008/11/06/generic-adapter-class-in-python/
 https://sourcemaking.com/design_patterns/adapter
 http://python-3-patterns-idioms-test.readthedocs.io/en/latest/ChangeInterface.html#adapter
 
-*TL;DR80
+*TL;DR
 Allows the interface of an existing class to be used as another interface.
 """
 

--- a/patterns/structural/bridge.py
+++ b/patterns/structural/bridge.py
@@ -5,7 +5,7 @@
 *References:
 http://en.wikibooks.org/wiki/Computer_Science_Design_Patterns/Bridge_Pattern#Python
 
-*TL;DR80
+*TL;DR
 Decouples an abstraction from its implementation.
 """
 

--- a/patterns/structural/composite.py
+++ b/patterns/structural/composite.py
@@ -25,7 +25,7 @@ program to deal with all shapes uniformly.
 https://en.wikipedia.org/wiki/Composite_pattern
 https://infinitescript.com/2014/10/the-23-gang-of-three-design-patterns/
 
-*TL;DR80
+*TL;DR
 Describes a group of objects that is treated as a single instance.
 """
 

--- a/patterns/structural/decorator.py
+++ b/patterns/structural/decorator.py
@@ -23,7 +23,7 @@ http://grok.zope.org/doc/current/reference/decorators.html
 *References:
 https://sourcemaking.com/design_patterns/decorator
 
-*TL;DR80
+*TL;DR
 Adds behaviour to object without affecting its class.
 """
 

--- a/patterns/structural/facade.py
+++ b/patterns/structural/facade.py
@@ -27,7 +27,7 @@ https://sourcemaking.com/design_patterns/facade
 https://fkromer.github.io/python-pattern-references/design/#facade
 http://python-3-patterns-idioms-test.readthedocs.io/en/latest/ChangeInterface.html#facade
 
-*TL;DR80
+*TL;DR
 Provides a simpler unified interface to a complex system.
 """
 

--- a/patterns/structural/flyweight__py2.py
+++ b/patterns/structural/flyweight__py2.py
@@ -20,7 +20,7 @@ objects initialised by the program.
 *References:
 http://codesnipers.com/?q=python-flyweights
 
-*TL;DR80
+*TL;DR
 Minimizes memory usage by sharing data with other similar objects.
 """
 

--- a/patterns/structural/flyweight__py3.py
+++ b/patterns/structural/flyweight__py3.py
@@ -24,7 +24,7 @@ https://python-patterns.guide/gang-of-four/flyweight/
 *Examples in Python ecosystem:
 https://docs.python.org/3/library/sys.html#sys.intern
 
-*TL;DR80
+*TL;DR
 Minimizes memory usage by sharing data with other similar objects.
 """
 

--- a/patterns/structural/front_controller.py
+++ b/patterns/structural/front_controller.py
@@ -4,7 +4,7 @@
 """
 @author: Gordeev Andrey <gordeev.and.and@gmail.com>
 
-*TL;DR80
+*TL;DR
 Provides a centralized entry point that controls and manages request handling.
 """
 

--- a/patterns/structural/mvc.py
+++ b/patterns/structural/mvc.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 """
-*TL;DR80
+*TL;DR
 Separates data in GUIs from the ways it is presented, and accepted.
 """
 

--- a/patterns/structural/proxy.py
+++ b/patterns/structural/proxy.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 """
-*TL;DR80
+*TL;DR
 Provides an interface to resource that is expensive to duplicate.
 """
 


### PR DESCRIPTION
I actually appreciate having the line length not going over `80` since I am an avid vim user, work of a laptop, and usually need 3 windows open at once.

I am removing this because I think it's meaning is ambiguous and even if it did indicate line-length, this rule isn't strictly adhered to.

Thanks @faif 

Closes: #228 