### PR TITLE
Use random.seed for deterministic doctest outputs

### DIFF
--- a/patterns/other/blackboard.py
+++ b/patterns/other/blackboard.py
@@ -90,30 +90,37 @@ class Professor(AbstractExpert):
         self.blackboard.common_state['progress'] += random.randint(10, 100)
 
 
+def main():
+    """
+    >>> blackboard = Blackboard()
+    >>> blackboard.add_expert(Student(blackboard))
+    >>> blackboard.add_expert(Scientist(blackboard))
+    >>> blackboard.add_expert(Professor(blackboard))
+
+    >>> c = Controller(blackboard)
+    >>> contributions = c.run_loop()
+
+    >>> from pprint import pprint
+    >>> pprint(contributions)
+    ['Student',
+     'Student',
+     'Student',
+     'Student',
+     'Scientist',
+     'Student',
+     'Student',
+     'Student',
+     'Scientist',
+     'Student',
+     'Scientist',
+     'Student',
+     'Student',
+     'Scientist',
+     'Professor']
+    """
+
+
 if __name__ == '__main__':
-    blackboard = Blackboard()
-
-    blackboard.add_expert(Student(blackboard))
-    blackboard.add_expert(Scientist(blackboard))
-    blackboard.add_expert(Professor(blackboard))
-
-    c = Controller(blackboard)
-    contributions = c.run_loop()
-
-    from pprint import pprint
-
-    pprint(contributions)
-
-### OUTPUT ###
-# ['Student',
-#  'Student',
-#  'Scientist',
-#  'Student',
-#  'Scientist',
-#  'Student',
-#  'Scientist',
-#  'Student',
-#  'Scientist',
-#  'Student',
-#  'Scientist',
-#  'Professor']
+    random.seed(1234)  # for deterministic doctest outputs
+    import doctest
+    doctest.testmod()

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,3 +3,4 @@
 pytest~=4.3.0
 pytest-cov~=2.6.0
 flake8~=3.7.0
+pytest-randomly~=3.1.0

--- a/tox.ini
+++ b/tox.ini
@@ -9,8 +9,10 @@ deps =
     -r requirements-dev.txt
 commands =
     flake8 patterns/
-    pytest --doctest-modules patterns/
-    pytest -s -vv --cov={envsitepackagesdir}/patterns --log-level=INFO tests/
+    ; `randomly-seed` option from `pytest-randomly` helps with deterministic outputs for examples like `other/blackboard.py`
+    pytest --randomly-seed=1234 --doctest-modules patterns/
+    ; `-p no:randomly` turns off `randomly` plugin for unit tests
+    pytest -s -vv --cov={envsitepackagesdir}/patterns --log-level=INFO -p no:randomly tests/
 
 
 [testenv:cov-report]


### PR DESCRIPTION
This PR was intended to add doctest for `blackboard.py`.
As a workaround for `random` outputs - `random.seed` was used.
- `random.seed(1234)` if you should run script by hand like `python patterns/other/blackboard.py`
- `pytest-randomly` plugin to run via `pytest`

I've added related comments to `tox.ini` but need to explain a bit futher: 
For unittest part - plugin is disabled not because of `random.*` outputs, but because plugin shuffles order of tests and it has found another issue (some tests depend on their order). I haven't investigated it further for the moment, will do it a bit later.


Please let me know if someone has simpler way of testing with `random.*` or sees problems with current approach.
p.s. there is another script with use of random - `abstract_factory`. And so I can fix it after.
