### PR TITLE
Added type hints to delegation pattern

### DIFF
--- a/patterns/fundamental/delegation_pattern.py
+++ b/patterns/fundamental/delegation_pattern.py
@@ -6,6 +6,9 @@ Author: https://github.com/IuryAlves
 Allows object composition to achieve the same code reuse as inheritance.
 """
 
+from __future__ import annotations
+from typing import Any, Callable, Union
+
 
 class Delegator:
     """
@@ -24,10 +27,10 @@ class Delegator:
     AttributeError: 'Delegate' object has no attribute 'do_anything'
     """
 
-    def __init__(self, delegate):
+    def __init__(self, delegate: Delegate):
         self.delegate = delegate
 
-    def __getattr__(self, name):
+    def __getattr__(self, name: str) -> Union[Any, Callable]:
         attr = getattr(self.delegate, name)
 
         if not callable(attr):
@@ -35,6 +38,7 @@ class Delegator:
 
         def wrapper(*args, **kwargs):
             return attr(*args, **kwargs)
+
         return wrapper
 
 
@@ -42,11 +46,11 @@ class Delegate:
     def __init__(self):
         self.p1 = 123
 
-    def do_something(self, something):
-        return "Doing %s" % something
+    def do_something(self, something: str) -> str:
+        return f"Doing {something}"
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     import doctest
 
     doctest.testmod()


### PR DESCRIPTION
**Delegation** pattern can be much easier to understand with **type annotations**. It doesn't affect the tests. Tested on python 3.6, 3,7 and 3.8. I also suggest adding type hints gradually to other examples too. This can make the intents of the code snippets much clearer.  

Also fixed some minor formatting issues (Adding 2 empty lines after import, double quoting the strings everywhere etc.)