### PR TITLE
Added type hint to command pattern

### DIFF
--- a/makefile
+++ b/makefile
@@ -1,0 +1,88 @@
+# REDNAFI
+# This only works with embedded venv not virtualenv
+# Install venv: python3.8 -m venv venv
+# Activate venv: source venv/bin/activate
+
+# Usage (line =black line length, path = action path, ignore= exclude folders)
+# ------
+# make pylinter [make pylinter line=88 path=.]
+# make pyupgrade
+
+path := .
+line := 88
+ignore := *env
+
+all:
+	@echo
+
+.PHONY: checkvenv
+checkvenv:
+# raises error if environment is not active
+ifeq ("$(VIRTUAL_ENV)","")
+	@echo "Venv is not activated!"
+	@echo "Activate venv first."
+	@echo
+	exit 1
+endif
+
+.PHONY: pyupgrade
+pyupgrade: checkvenv
+# checks if pip-tools is installed
+ifeq ("$(wildcard venv/bin/pip-compile)","")
+	@echo "Installing Pip-tools..."
+	@pip install pip-tools
+endif
+
+ifeq ("$(wildcard venv/bin/pip-sync)","")
+	@echo "Installing Pip-tools..."
+	@pip install pip-tools
+endif
+
+# pip-tools
+	@pip-compile --upgrade requirements-dev.txt
+	@pip-compile --upgrade requirements.txt
+	@pip-sync requirements-dev.txt requirements.txt
+
+
+.PHONY: pylinter
+pylinter: checkvenv
+# checks if black is installed
+ifeq ("$(wildcard venv/bin/black)","")
+	@echo "Installing Black..."
+	@pip install black
+endif
+
+# checks if isort is installed
+ifeq ("$(wildcard venv/bin/isort)","")
+	@echo "Installing Isort..."
+	@pip install isort
+endif
+
+# checks if flake8 is installed
+ifeq ("$(wildcard venv/bin/flake8)","")
+	@echo -e "Installing flake8..."
+	@pip install flake8
+	@echo
+endif
+
+# black
+	@echo "Applying Black"
+	@echo "----------------\n"
+	@black --line-length $(line) --exclude $(ignore) $(path)
+	@echo
+
+# isort
+	@echo "Applying Isort"
+	@echo "----------------\n"
+	@isort --atomic --profile black $(path)
+	@echo
+
+# flake8
+	@echo "Applying Flake8"
+	@echo "----------------\n"
+	@flake8 --max-line-length "$(line)" \
+			--max-complexity "18" \
+			--select "B,C,E,F,W,T4,B9" \
+			--ignore "E203,E266,E501,W503,F403,F401,E402" \
+			--exclude ".git,__pycache__,old, build, \
+						dist, venv" $(path)

--- a/patterns/behavioral/chain_of_responsibility.py
+++ b/patterns/behavioral/chain_of_responsibility.py
@@ -21,7 +21,6 @@ Allow a request to pass down a chain of receivers until it is handled.
 from abc import ABC, abstractmethod
 from typing import Callable, Optional, Tuple, TypeVar
 
-
 T = TypeVar("T")
 
 
@@ -115,4 +114,5 @@ def main():
 
 if __name__ == "__main__":
     import doctest
+
     doctest.testmod(optionflags=doctest.ELLIPSIS)

--- a/patterns/behavioral/chaining_method.py
+++ b/patterns/behavioral/chaining_method.py
@@ -4,7 +4,7 @@ class Person:
         self.action = action
 
     def do_action(self):
-        print(self.name, self.action.name, end=' ')
+        print(self.name, self.action.name, end=" ")
         return self.action
 
 
@@ -13,11 +13,11 @@ class Action:
         self.name = name
 
     def amount(self, val):
-        print(val, end=' ')
+        print(val, end=" ")
         return self
 
     def stop(self):
-        print('then stop')
+        print("then stop")
 
 
 def main():
@@ -29,6 +29,7 @@ def main():
     """
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     import doctest
+
     doctest.testmod()

--- a/patterns/behavioral/command.py
+++ b/patterns/behavioral/command.py
@@ -20,23 +20,25 @@ Django HttpRequest (without execute method):
 https://docs.djangoproject.com/en/2.1/ref/request-response/#httprequest-objects
 """
 
+from typing import Union
+
 
 class HideFileCommand:
     """
     A command to hide a file given its name
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         # an array of files hidden, to undo them as needed
         self._hidden_files = []
 
-    def execute(self, filename):
-        print(f'hiding {filename}')
+    def execute(self, filename: str) -> None:
+        print(f"hiding {filename}")
         self._hidden_files.append(filename)
 
-    def undo(self):
+    def undo(self) -> None:
         filename = self._hidden_files.pop()
-        print(f'un-hiding {filename}')
+        print(f"un-hiding {filename}")
 
 
 class DeleteFileCommand:
@@ -44,17 +46,17 @@ class DeleteFileCommand:
     A command to delete a file given its name
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         # an array of deleted files, to undo them as needed
         self._deleted_files = []
 
-    def execute(self, filename):
-        print(f'deleting {filename}')
+    def execute(self, filename: str) -> None:
+        print(f"deleting {filename}")
         self._deleted_files.append(filename)
 
-    def undo(self):
+    def undo(self) -> None:
         filename = self._deleted_files.pop()
-        print(f'restoring {filename}')
+        print(f"restoring {filename}")
 
 
 class MenuItem:
@@ -62,13 +64,13 @@ class MenuItem:
     The invoker class. Here it is items in a menu.
     """
 
-    def __init__(self, command):
+    def __init__(self, command: Union[HideFileCommand, DeleteFileCommand]) -> None:
         self._command = command
 
-    def on_do_press(self, filename):
+    def on_do_press(self, filename: str) -> None:
         self._command.execute(filename)
 
-    def on_undo_press(self):
+    def on_undo_press(self) -> None:
         self._command.undo()
 
 
@@ -101,4 +103,5 @@ def main():
 
 if __name__ == "__main__":
     import doctest
+
     doctest.testmod()

--- a/patterns/behavioral/iterator.py
+++ b/patterns/behavioral/iterator.py
@@ -40,4 +40,5 @@ def main():
 
 if __name__ == "__main__":
     import doctest
+
     doctest.testmod()

--- a/patterns/behavioral/iterator_alt.py
+++ b/patterns/behavioral/iterator_alt.py
@@ -8,12 +8,13 @@ Traverses a container and accesses the container's elements.
 
 class NumberWords:
     """Counts by word numbers, up to a maximum of five"""
+
     _WORD_MAP = (
-        'one',
-        'two',
-        'three',
-        'four',
-        'five',
+        "one",
+        "two",
+        "three",
+        "four",
+        "five",
     )
 
     def __init__(self, start, stop):
@@ -32,6 +33,7 @@ class NumberWords:
 
 
 # Test the iterator
+
 
 def main():
     """

--- a/patterns/behavioral/mediator.py
+++ b/patterns/behavioral/mediator.py
@@ -45,6 +45,7 @@ def main():
     """
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     import doctest
+
     doctest.testmod()

--- a/patterns/behavioral/memento.py
+++ b/patterns/behavioral/memento.py
@@ -5,8 +5,7 @@ http://code.activestate.com/recipes/413838-memento-closure/
 Provides the ability to restore an object to its previous state.
 """
 
-from copy import copy
-from copy import deepcopy
+from copy import copy, deepcopy
 
 
 def memento(obj, deep=False):
@@ -67,14 +66,14 @@ class NumObj:
         self.value = value
 
     def __repr__(self):
-        return '<%s: %r>' % (self.__class__.__name__, self.value)
+        return "<%s: %r>" % (self.__class__.__name__, self.value)
 
     def increment(self):
         self.value += 1
 
     @Transactional
     def do_stuff(self):
-        self.value = '1111'  # <- invalid value
+        self.value = "1111"  # <- invalid value
         self.increment()  # <- will fail and rollback
 
 
@@ -134,4 +133,5 @@ def main():
 
 if __name__ == "__main__":
     import doctest
+
     doctest.testmod(optionflags=doctest.ELLIPSIS)

--- a/patterns/behavioral/observer.py
+++ b/patterns/behavioral/observer.py
@@ -31,7 +31,7 @@ class Subject:
 
 
 class Data(Subject):
-    def __init__(self, name=''):
+    def __init__(self, name=""):
         Subject.__init__(self)
         self.name = name
         self._data = 0
@@ -48,12 +48,14 @@ class Data(Subject):
 
 class HexViewer:
     def update(self, subject):
-        print('HexViewer: Subject {} has data 0x{:x}'.format(subject.name, subject.data))
+        print(
+            "HexViewer: Subject {} has data 0x{:x}".format(subject.name, subject.data)
+        )
 
 
 class DecimalViewer:
     def update(self, subject):
-        print('DecimalViewer: Subject %s has data %d' % (subject.name, subject.data))
+        print("DecimalViewer: Subject %s has data %d" % (subject.name, subject.data))
 
 
 def main():
@@ -97,4 +99,5 @@ def main():
 
 if __name__ == "__main__":
     import doctest
+
     doctest.testmod()

--- a/patterns/behavioral/publish_subscribe.py
+++ b/patterns/behavioral/publish_subscribe.py
@@ -89,4 +89,5 @@ def main():
 
 if __name__ == "__main__":
     import doctest
+
     doctest.testmod()

--- a/patterns/behavioral/registry.py
+++ b/patterns/behavioral/registry.py
@@ -42,4 +42,5 @@ def main():
 
 if __name__ == "__main__":
     import doctest
+
     doctest.testmod(optionflags=doctest.ELLIPSIS)

--- a/patterns/behavioral/specification.py
+++ b/patterns/behavioral/specification.py
@@ -47,7 +47,10 @@ class AndSpecification(CompositeSpecification):
         self._other = other
 
     def is_satisfied_by(self, candidate):
-        return bool(self._one.is_satisfied_by(candidate) and self._other.is_satisfied_by(candidate))
+        return bool(
+            self._one.is_satisfied_by(candidate)
+            and self._other.is_satisfied_by(candidate)
+        )
 
 
 class OrSpecification(CompositeSpecification):
@@ -59,7 +62,10 @@ class OrSpecification(CompositeSpecification):
         self._other = other
 
     def is_satisfied_by(self, candidate):
-        return bool(self._one.is_satisfied_by(candidate) or self._other.is_satisfied_by(candidate))
+        return bool(
+            self._one.is_satisfied_by(candidate)
+            or self._other.is_satisfied_by(candidate)
+        )
 
 
 class NotSpecification(CompositeSpecification):
@@ -84,7 +90,7 @@ class UserSpecification(CompositeSpecification):
 
 class SuperUserSpecification(CompositeSpecification):
     def is_satisfied_by(self, candidate):
-        return getattr(candidate, 'super_user', False)
+        return getattr(candidate, "super_user", False)
 
 
 def main():
@@ -105,6 +111,7 @@ def main():
     """
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     import doctest
+
     doctest.testmod()

--- a/patterns/behavioral/state.py
+++ b/patterns/behavioral/state.py
@@ -83,6 +83,7 @@ def main():
     """
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     import doctest
+
     doctest.testmod()

--- a/patterns/behavioral/strategy.py
+++ b/patterns/behavioral/strategy.py
@@ -48,4 +48,5 @@ def main():
 
 if __name__ == "__main__":
     import doctest
+
     doctest.testmod()

--- a/patterns/behavioral/template.py
+++ b/patterns/behavioral/template.py
@@ -69,4 +69,5 @@ def main():
 
 if __name__ == "__main__":
     import doctest
+
     doctest.testmod()

--- a/patterns/behavioral/visitor.py
+++ b/patterns/behavioral/visitor.py
@@ -36,7 +36,7 @@ class Visitor:
     def visit(self, node, *args, **kwargs):
         meth = None
         for cls in node.__class__.__mro__:
-            meth_name = 'visit_' + cls.__name__
+            meth_name = "visit_" + cls.__name__
             meth = getattr(self, meth_name, None)
             if meth:
                 break
@@ -46,10 +46,10 @@ class Visitor:
         return meth(node, *args, **kwargs)
 
     def generic_visit(self, node, *args, **kwargs):
-        print('generic_visit ' + node.__class__.__name__)
+        print("generic_visit " + node.__class__.__name__)
 
     def visit_B(self, node, *args, **kwargs):
-        print('visit_B ' + node.__class__.__name__)
+        print("visit_B " + node.__class__.__name__)
 
 
 def main():
@@ -70,4 +70,5 @@ def main():
 
 if __name__ == "__main__":
     import doctest
+
     doctest.testmod()

--- a/patterns/creational/abstract_factory.py
+++ b/patterns/creational/abstract_factory.py
@@ -101,6 +101,7 @@ def main():
 
 
 if __name__ == "__main__":
-    random.seed(1234)   # for deterministic doctest outputs
+    random.seed(1234)  # for deterministic doctest outputs
     import doctest
+
     doctest.testmod()

--- a/patterns/creational/borg.py
+++ b/patterns/creational/borg.py
@@ -42,19 +42,18 @@ class Borg:
 
 
 class YourBorg(Borg):
-
     def __init__(self, state=None):
         super().__init__()
         if state:
             self.state = state
         else:
             # initiate the first instance with default state
-            if not hasattr(self, 'state'):
-                self.state = 'Init'
+            if not hasattr(self, "state"):
+                self.state = "Init"
 
     def __str__(self):
         return self.state
-        
+
 
 def main():
     """
@@ -106,4 +105,5 @@ def main():
 
 if __name__ == "__main__":
     import doctest
+
     doctest.testmod()

--- a/patterns/creational/builder.py
+++ b/patterns/creational/builder.py
@@ -45,24 +45,24 @@ class Building:
         raise NotImplementedError
 
     def __repr__(self):
-        return 'Floor: {0.floor} | Size: {0.size}'.format(self)
+        return "Floor: {0.floor} | Size: {0.size}".format(self)
 
 
 # Concrete Buildings
 class House(Building):
     def build_floor(self):
-        self.floor = 'One'
+        self.floor = "One"
 
     def build_size(self):
-        self.size = 'Big'
+        self.size = "Big"
 
 
 class Flat(Building):
     def build_floor(self):
-        self.floor = 'More than One'
+        self.floor = "More than One"
 
     def build_size(self):
-        self.size = 'Small'
+        self.size = "Small"
 
 
 # In some very complex cases, it might be desirable to pull out the building
@@ -73,15 +73,15 @@ class Flat(Building):
 
 class ComplexBuilding:
     def __repr__(self):
-        return 'Floor: {0.floor} | Size: {0.size}'.format(self)
+        return "Floor: {0.floor} | Size: {0.size}".format(self)
 
 
 class ComplexHouse(ComplexBuilding):
     def build_floor(self):
-        self.floor = 'One'
+        self.floor = "One"
 
     def build_size(self):
-        self.size = 'Big and fancy'
+        self.size = "Big and fancy"
 
 
 def construct_building(cls):
@@ -110,4 +110,5 @@ def main():
 
 if __name__ == "__main__":
     import doctest
+
     doctest.testmod()

--- a/patterns/creational/lazy_evaluation.py
+++ b/patterns/creational/lazy_evaluation.py
@@ -36,7 +36,7 @@ class lazy_property:
 
 
 def lazy_property2(fn):
-    attr = '_lazy__' + fn.__name__
+    attr = "_lazy__" + fn.__name__
 
     @property
     def _lazy_property(self):
@@ -101,4 +101,5 @@ def main():
 
 if __name__ == "__main__":
     import doctest
+
     doctest.testmod(optionflags=doctest.ELLIPSIS)

--- a/patterns/creational/pool.py
+++ b/patterns/creational/pool.py
@@ -80,6 +80,7 @@ def main():
     """
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     import doctest
+
     doctest.testmod()

--- a/patterns/creational/prototype.py
+++ b/patterns/creational/prototype.py
@@ -24,7 +24,7 @@ Creates new object instances by cloning prototype.
 
 class Prototype:
 
-    value = 'default'
+    value = "default"
 
     def clone(self, **attrs):
         """Clone a prototype and update inner attributes dictionary"""
@@ -68,6 +68,7 @@ def main():
     """
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     import doctest
+
     doctest.testmod()

--- a/patterns/fundamental/delegation_pattern.py
+++ b/patterns/fundamental/delegation_pattern.py
@@ -7,6 +7,7 @@ Allows object composition to achieve the same code reuse as inheritance.
 """
 
 from __future__ import annotations
+
 from typing import Any, Callable, Union
 
 

--- a/patterns/other/blackboard.py
+++ b/patterns/other/blackboard.py
@@ -17,10 +17,10 @@ class Blackboard:
     def __init__(self):
         self.experts = []
         self.common_state = {
-            'problems': 0,
-            'suggestions': 0,
-            'contributions': [],
-            'progress': 0,  # percentage, if 100 -> task is finished
+            "problems": 0,
+            "suggestions": 0,
+            "contributions": [],
+            "progress": 0,  # percentage, if 100 -> task is finished
         }
 
     def add_expert(self, expert):
@@ -32,26 +32,25 @@ class Controller:
         self.blackboard = blackboard
 
     def run_loop(self):
-        while self.blackboard.common_state['progress'] < 100:
+        while self.blackboard.common_state["progress"] < 100:
             for expert in self.blackboard.experts:
                 if expert.is_eager_to_contribute:
                     expert.contribute()
-        return self.blackboard.common_state['contributions']
+        return self.blackboard.common_state["contributions"]
 
 
 class AbstractExpert(metaclass=abc.ABCMeta):
-
     def __init__(self, blackboard):
         self.blackboard = blackboard
 
     @property
     @abc.abstractmethod
     def is_eager_to_contribute(self):
-        raise NotImplementedError('Must provide implementation in subclass.')
+        raise NotImplementedError("Must provide implementation in subclass.")
 
     @abc.abstractmethod
     def contribute(self):
-        raise NotImplementedError('Must provide implementation in subclass.')
+        raise NotImplementedError("Must provide implementation in subclass.")
 
 
 class Student(AbstractExpert):
@@ -60,10 +59,10 @@ class Student(AbstractExpert):
         return True
 
     def contribute(self):
-        self.blackboard.common_state['problems'] += random.randint(1, 10)
-        self.blackboard.common_state['suggestions'] += random.randint(1, 10)
-        self.blackboard.common_state['contributions'] += [self.__class__.__name__]
-        self.blackboard.common_state['progress'] += random.randint(1, 2)
+        self.blackboard.common_state["problems"] += random.randint(1, 10)
+        self.blackboard.common_state["suggestions"] += random.randint(1, 10)
+        self.blackboard.common_state["contributions"] += [self.__class__.__name__]
+        self.blackboard.common_state["progress"] += random.randint(1, 2)
 
 
 class Scientist(AbstractExpert):
@@ -72,22 +71,22 @@ class Scientist(AbstractExpert):
         return random.randint(0, 1)
 
     def contribute(self):
-        self.blackboard.common_state['problems'] += random.randint(10, 20)
-        self.blackboard.common_state['suggestions'] += random.randint(10, 20)
-        self.blackboard.common_state['contributions'] += [self.__class__.__name__]
-        self.blackboard.common_state['progress'] += random.randint(10, 30)
+        self.blackboard.common_state["problems"] += random.randint(10, 20)
+        self.blackboard.common_state["suggestions"] += random.randint(10, 20)
+        self.blackboard.common_state["contributions"] += [self.__class__.__name__]
+        self.blackboard.common_state["progress"] += random.randint(10, 30)
 
 
 class Professor(AbstractExpert):
     @property
     def is_eager_to_contribute(self):
-        return True if self.blackboard.common_state['problems'] > 100 else False
+        return True if self.blackboard.common_state["problems"] > 100 else False
 
     def contribute(self):
-        self.blackboard.common_state['problems'] += random.randint(1, 2)
-        self.blackboard.common_state['suggestions'] += random.randint(10, 20)
-        self.blackboard.common_state['contributions'] += [self.__class__.__name__]
-        self.blackboard.common_state['progress'] += random.randint(10, 100)
+        self.blackboard.common_state["problems"] += random.randint(1, 2)
+        self.blackboard.common_state["suggestions"] += random.randint(10, 20)
+        self.blackboard.common_state["contributions"] += [self.__class__.__name__]
+        self.blackboard.common_state["progress"] += random.randint(10, 100)
 
 
 def main():
@@ -120,7 +119,8 @@ def main():
     """
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     random.seed(1234)  # for deterministic doctest outputs
     import doctest
+
     doctest.testmod()

--- a/patterns/other/graph_search.py
+++ b/patterns/other/graph_search.py
@@ -65,4 +65,5 @@ def main():
 
 if __name__ == "__main__":
     import doctest
+
     doctest.testmod()

--- a/patterns/other/hsm/hsm.py
+++ b/patterns/other/hsm/hsm.py
@@ -29,17 +29,17 @@ class HierachicalStateMachine:
         self._failed_state = Failed(self)  # Unit.OutOfService.Failed()
         self._current_state = self._standby_state
         self.states = {
-            'active': self._active_state,
-            'standby': self._standby_state,
-            'suspect': self._suspect_state,
-            'failed': self._failed_state,
+            "active": self._active_state,
+            "standby": self._standby_state,
+            "suspect": self._suspect_state,
+            "failed": self._failed_state,
         }
         self.message_types = {
-            'fault trigger': self._current_state.on_fault_trigger,
-            'switchover': self._current_state.on_switchover,
-            'diagnostics passed': self._current_state.on_diagnostics_passed,
-            'diagnostics failed': self._current_state.on_diagnostics_failed,
-            'operator inservice': self._current_state.on_operator_inservice,
+            "fault trigger": self._current_state.on_fault_trigger,
+            "switchover": self._current_state.on_switchover,
+            "diagnostics passed": self._current_state.on_diagnostics_passed,
+            "diagnostics failed": self._current_state.on_diagnostics_failed,
+            "operator inservice": self._current_state.on_operator_inservice,
         }
 
     def _next_state(self, state):
@@ -49,34 +49,34 @@ class HierachicalStateMachine:
             raise UnsupportedState
 
     def _send_diagnostics_request(self):
-        return 'send diagnostic request'
+        return "send diagnostic request"
 
     def _raise_alarm(self):
-        return 'raise alarm'
+        return "raise alarm"
 
     def _clear_alarm(self):
-        return 'clear alarm'
+        return "clear alarm"
 
     def _perform_switchover(self):
-        return 'perform switchover'
+        return "perform switchover"
 
     def _send_switchover_response(self):
-        return 'send switchover response'
+        return "send switchover response"
 
     def _send_operator_inservice_response(self):
-        return 'send operator inservice response'
+        return "send operator inservice response"
 
     def _send_diagnostics_failure_report(self):
-        return 'send diagnostics failure report'
+        return "send diagnostics failure report"
 
     def _send_diagnostics_pass_report(self):
-        return 'send diagnostics pass report'
+        return "send diagnostics pass report"
 
     def _abort_diagnostics(self):
-        return 'abort diagnostics'
+        return "abort diagnostics"
 
     def _check_mate_status(self):
-        return 'check mate status'
+        return "check mate status"
 
     def on_message(self, message_type):  # message ignored
         if message_type in self.message_types.keys():
@@ -110,7 +110,7 @@ class Inservice(Unit):
         self._hsm = HierachicalStateMachine
 
     def on_fault_trigger(self):
-        self._hsm._next_state('suspect')
+        self._hsm._next_state("suspect")
         self._hsm._send_diagnostics_request()
         self._hsm._raise_alarm()
 
@@ -130,7 +130,7 @@ class Active(Inservice):
 
     def on_switchover(self):
         self._hsm.on_switchover()  # message ignored
-        self._hsm.next_state('standby')
+        self._hsm.next_state("standby")
 
 
 class Standby(Inservice):
@@ -139,7 +139,7 @@ class Standby(Inservice):
 
     def on_switchover(self):
         super().on_switchover()  # message ignored
-        self._hsm._next_state('active')
+        self._hsm._next_state("active")
 
 
 class OutOfService(Unit):
@@ -149,7 +149,7 @@ class OutOfService(Unit):
     def on_operator_inservice(self):
         self._hsm.on_switchover()  # message ignored
         self._hsm.send_operator_inservice_response()
-        self._hsm.next_state('suspect')
+        self._hsm.next_state("suspect")
 
 
 class Suspect(OutOfService):
@@ -158,12 +158,12 @@ class Suspect(OutOfService):
 
     def on_diagnostics_failed(self):
         super().send_diagnostics_failure_report()
-        super().next_state('failed')
+        super().next_state("failed")
 
     def on_diagnostics_passed(self):
         super().send_diagnostics_pass_report()
         super().clear_alarm()  # loss of redundancy alarm
-        super().next_state('standby')
+        super().next_state("standby")
 
     def on_operator_inservice(self):
         super().abort_diagnostics()

--- a/patterns/structural/3-tier.py
+++ b/patterns/structural/3-tier.py
@@ -94,4 +94,5 @@ def main():
 
 if __name__ == "__main__":
     import doctest
+
     doctest.testmod()

--- a/patterns/structural/bridge.py
+++ b/patterns/structural/bridge.py
@@ -10,13 +10,13 @@ Decouples an abstraction from its implementation.
 # ConcreteImplementor 1/2
 class DrawingAPI1:
     def draw_circle(self, x, y, radius):
-        print('API1.circle at {}:{} radius {}'.format(x, y, radius))
+        print("API1.circle at {}:{} radius {}".format(x, y, radius))
 
 
 # ConcreteImplementor 2/2
 class DrawingAPI2:
     def draw_circle(self, x, y, radius):
-        print('API2.circle at {}:{} radius {}'.format(x, y, radius))
+        print("API2.circle at {}:{} radius {}".format(x, y, radius))
 
 
 # Refined Abstraction
@@ -48,6 +48,7 @@ def main():
     """
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     import doctest
+
     doctest.testmod()

--- a/patterns/structural/composite.py
+++ b/patterns/structural/composite.py
@@ -89,4 +89,5 @@ def main():
 
 if __name__ == "__main__":
     import doctest
+
     doctest.testmod()

--- a/patterns/structural/decorator.py
+++ b/patterns/structural/decorator.py
@@ -68,6 +68,7 @@ def main():
     """
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     import doctest
+
     doctest.testmod()

--- a/patterns/structural/facade.py
+++ b/patterns/structural/facade.py
@@ -34,6 +34,7 @@ class CPU:
     """
     Simple CPU representation.
     """
+
     def freeze(self):
         print("Freezing processor.")
 
@@ -48,6 +49,7 @@ class Memory:
     """
     Simple memory representation.
     """
+
     def load(self, position, data):
         print("Loading from {0} data: '{1}'.".format(position, data))
 
@@ -56,6 +58,7 @@ class SolidStateDrive:
     """
     Simple solid state drive representation.
     """
+
     def read(self, lba, size):
         return "Some data from sector {0} with size {1}".format(lba, size)
 
@@ -64,6 +67,7 @@ class ComputerFacade:
     """
     Represents a facade for various computer parts.
     """
+
     def __init__(self):
         self.cpu = CPU()
         self.memory = Memory()
@@ -89,4 +93,5 @@ def main():
 
 if __name__ == "__main__":
     import doctest
+
     doctest.testmod(optionflags=doctest.ELLIPSIS)

--- a/patterns/structural/flyweight.py
+++ b/patterns/structural/flyweight.py
@@ -81,4 +81,5 @@ def main():
 
 if __name__ == "__main__":
     import doctest
+
     doctest.testmod()

--- a/patterns/structural/flyweight_with_metaclass.py
+++ b/patterns/structural/flyweight_with_metaclass.py
@@ -12,7 +12,7 @@ class FlyweightMeta(type):
         static methods, etc
         :return: new class
         """
-        dct['pool'] = weakref.WeakValueDictionary()
+        dct["pool"] = weakref.WeakValueDictionary()
         return super().__new__(mcs, name, parents, dct)
 
     @staticmethod
@@ -23,12 +23,12 @@ class FlyweightMeta(type):
         """
         args_list = list(map(str, args))
         args_list.extend([str(kwargs), cls.__name__])
-        key = ''.join(args_list)
+        key = "".join(args_list)
         return key
 
     def __call__(cls, *args, **kwargs):
         key = FlyweightMeta._serialize_params(cls, *args, **kwargs)
-        pool = getattr(cls, 'pool', {})
+        pool = getattr(cls, "pool", {})
 
         instance = pool.get(key)
         if instance is None:
@@ -43,11 +43,11 @@ class Card2(metaclass=FlyweightMeta):
         pass
 
 
-if __name__ == '__main__':
-    instances_pool = getattr(Card2, 'pool')
-    cm1 = Card2('10', 'h', a=1)
-    cm2 = Card2('10', 'h', a=1)
-    cm3 = Card2('10', 'h', a=2)
+if __name__ == "__main__":
+    instances_pool = getattr(Card2, "pool")
+    cm1 = Card2("10", "h", a=1)
+    cm2 = Card2("10", "h", a=1)
+    cm3 = Card2("10", "h", a=2)
 
     assert (cm1 == cm2) and (cm1 != cm3)
     assert (cm1 is cm2) and (cm1 is not cm3)

--- a/patterns/structural/front_controller.py
+++ b/patterns/structural/front_controller.py
@@ -8,12 +8,12 @@ Provides a centralized entry point that controls and manages request handling.
 
 class MobileView:
     def show_index_page(self):
-        print('Displaying mobile index page')
+        print("Displaying mobile index page")
 
 
 class TabletView:
     def show_index_page(self):
-        print('Displaying tablet index page')
+        print("Displaying tablet index page")
 
 
 class Dispatcher:
@@ -27,7 +27,7 @@ class Dispatcher:
         elif request.type == Request.tablet_type:
             self.tablet_view.show_index_page()
         else:
-            print('cant dispatch the request')
+            print("cant dispatch the request")
 
 
 class RequestController:
@@ -40,14 +40,14 @@ class RequestController:
         if isinstance(request, Request):
             self.dispatcher.dispatch(request)
         else:
-            print('request must be a Request object')
+            print("request must be a Request object")
 
 
 class Request:
     """ request """
 
-    mobile_type = 'mobile'
-    tablet_type = 'tablet'
+    mobile_type = "mobile"
+    tablet_type = "tablet"
 
     def __init__(self, request):
         self.type = None
@@ -78,4 +78,5 @@ def main():
 
 if __name__ == "__main__":
     import doctest
+
     doctest.testmod()

--- a/patterns/structural/mvc.py
+++ b/patterns/structural/mvc.py
@@ -143,6 +143,7 @@ def main():
     """
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     import doctest
+
     doctest.testmod()

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from setuptools import setup, find_packages
+from setuptools import find_packages, setup
 
 setup(
     name="patterns",

--- a/tests/behavioral/test_observer.py
+++ b/tests/behavioral/test_observer.py
@@ -1,4 +1,4 @@
-from unittest.mock import patch, Mock
+from unittest.mock import Mock, patch
 
 import pytest
 
@@ -7,7 +7,8 @@ from patterns.behavioral.observer import Data, DecimalViewer, HexViewer
 
 @pytest.fixture
 def observable():
-    return Data('some data')
+    return Data("some data")
+
 
 def test_attach_detach(observable):
     decimal_viewer = DecimalViewer()
@@ -19,11 +20,14 @@ def test_attach_detach(observable):
     observable.detach(decimal_viewer)
     assert decimal_viewer not in observable._observers
 
+
 def test_one_data_change_notifies_each_observer_once(observable):
     observable.attach(DecimalViewer())
     observable.attach(HexViewer())
 
-    with patch('patterns.behavioral.observer.DecimalViewer.update', new_callable=Mock()) as mocked_update:
+    with patch(
+        "patterns.behavioral.observer.DecimalViewer.update", new_callable=Mock()
+    ) as mocked_update:
         assert mocked_update.call_count == 0
         observable.data = 10
         assert mocked_update.call_count == 1

--- a/tests/behavioral/test_publish_subscribe.py
+++ b/tests/behavioral/test_publish_subscribe.py
@@ -1,5 +1,6 @@
 import unittest
-from unittest.mock import patch, call
+from unittest.mock import call, patch
+
 from patterns.behavioral.publish_subscribe import Provider, Publisher, Subscriber
 
 
@@ -9,17 +10,17 @@ class TestProvider(unittest.TestCase):
     """
 
     def test_subscriber_shall_be_attachable_to_subscriptions(cls):
-        subscription = 'sub msg'
+        subscription = "sub msg"
         pro = Provider()
         cls.assertEqual(len(pro.subscribers), 0)
-        sub = Subscriber('sub name', pro)
+        sub = Subscriber("sub name", pro)
         sub.subscribe(subscription)
         cls.assertEqual(len(pro.subscribers[subscription]), 1)
 
     def test_subscriber_shall_be_detachable_from_subscriptions(cls):
-        subscription = 'sub msg'
+        subscription = "sub msg"
         pro = Provider()
-        sub = Subscriber('sub name', pro)
+        sub = Subscriber("sub name", pro)
         sub.subscribe(subscription)
         cls.assertEqual(len(pro.subscribers[subscription]), 1)
         sub.unsubscribe(subscription)
@@ -27,35 +28,41 @@ class TestProvider(unittest.TestCase):
 
     def test_publisher_shall_append_subscription_message_to_queue(cls):
         """ msg_queue ~ Provider.notify(msg) ~ Publisher.publish(msg) """
-        expected_msg = 'expected msg'
+        expected_msg = "expected msg"
         pro = Provider()
         pub = Publisher(pro)
-        Subscriber('sub name', pro)
+        Subscriber("sub name", pro)
         cls.assertEqual(len(pro.msg_queue), 0)
         pub.publish(expected_msg)
         cls.assertEqual(len(pro.msg_queue), 1)
         cls.assertEqual(pro.msg_queue[0], expected_msg)
 
-    def test_provider_shall_update_affected_subscribers_with_published_subscription(cls):
+    def test_provider_shall_update_affected_subscribers_with_published_subscription(
+        cls,
+    ):
         pro = Provider()
         pub = Publisher(pro)
-        sub1 = Subscriber('sub 1 name', pro)
-        sub1.subscribe('sub 1 msg 1')
-        sub1.subscribe('sub 1 msg 2')
-        sub2 = Subscriber('sub 2 name', pro)
-        sub2.subscribe('sub 2 msg 1')
-        sub2.subscribe('sub 2 msg 2')
-        with patch.object(sub1, 'run') as mock_subscriber1_run, patch.object(sub2, 'run') as mock_subscriber2_run:
+        sub1 = Subscriber("sub 1 name", pro)
+        sub1.subscribe("sub 1 msg 1")
+        sub1.subscribe("sub 1 msg 2")
+        sub2 = Subscriber("sub 2 name", pro)
+        sub2.subscribe("sub 2 msg 1")
+        sub2.subscribe("sub 2 msg 2")
+        with patch.object(sub1, "run") as mock_subscriber1_run, patch.object(
+            sub2, "run"
+        ) as mock_subscriber2_run:
             pro.update()
             cls.assertEqual(mock_subscriber1_run.call_count, 0)
             cls.assertEqual(mock_subscriber2_run.call_count, 0)
-        pub.publish('sub 1 msg 1')
-        pub.publish('sub 1 msg 2')
-        pub.publish('sub 2 msg 1')
-        pub.publish('sub 2 msg 2')
-        with patch.object(sub1, 'run') as mock_subscriber1_run, patch.object(sub2, 'run') as mock_subscriber2_run:
+        pub.publish("sub 1 msg 1")
+        pub.publish("sub 1 msg 2")
+        pub.publish("sub 2 msg 1")
+        pub.publish("sub 2 msg 2")
+        with patch.object(sub1, "run") as mock_subscriber1_run, patch.object(
+            sub2, "run"
+        ) as mock_subscriber2_run:
             pro.update()
-            expected_sub1_calls = [call('sub 1 msg 1'), call('sub 1 msg 2')]
+            expected_sub1_calls = [call("sub 1 msg 1"), call("sub 1 msg 2")]
             mock_subscriber1_run.assert_has_calls(expected_sub1_calls)
-            expected_sub2_calls = [call('sub 2 msg 1'), call('sub 2 msg 2')]
+            expected_sub2_calls = [call("sub 2 msg 1"), call("sub 2 msg 2")]
             mock_subscriber2_run.assert_has_calls(expected_sub2_calls)

--- a/tests/behavioral/test_state.py
+++ b/tests/behavioral/test_state.py
@@ -7,18 +7,21 @@ from patterns.behavioral.state import Radio
 def radio():
     return Radio()
 
+
 def test_initial_state(radio):
-    assert radio.state.name == 'AM'
+    assert radio.state.name == "AM"
+
 
 def test_initial_am_station(radio):
     initial_pos = radio.state.pos
-    assert radio.state.stations[initial_pos] == '1250'
+    assert radio.state.stations[initial_pos] == "1250"
+
 
 def test_toggle_amfm(radio):
-    assert radio.state.name == 'AM'
+    assert radio.state.name == "AM"
 
     radio.toggle_amfm()
-    assert radio.state.name == 'FM'
+    assert radio.state.name == "FM"
 
     radio.toggle_amfm()
-    assert radio.state.name == 'AM'
+    assert radio.state.name == "AM"

--- a/tests/creational/test_abstract_factory.py
+++ b/tests/creational/test_abstract_factory.py
@@ -1,12 +1,12 @@
 import unittest
 from unittest.mock import patch
 
-from patterns.creational.abstract_factory import PetShop, Dog
+from patterns.creational.abstract_factory import Dog, PetShop
 
 
 class TestPetShop(unittest.TestCase):
     def test_dog_pet_shop_shall_show_dog_instance(self):
         dog_pet_shop = PetShop(Dog)
-        with patch.object(Dog, 'speak') as mock_Dog_speak:
+        with patch.object(Dog, "speak") as mock_Dog_speak:
             dog_pet_shop.show_pet()
             self.assertEqual(mock_Dog_speak.call_count, 1)

--- a/tests/creational/test_borg.py
+++ b/tests/creational/test_borg.py
@@ -1,4 +1,5 @@
 import unittest
+
 from patterns.creational.borg import Borg, YourBorg
 
 
@@ -10,13 +11,13 @@ class BorgTest(unittest.TestCase):
 
     def test_initial_borg_state_shall_be_init(self):
         b = Borg()
-        self.assertEqual(b.state, 'Init')
+        self.assertEqual(b.state, "Init")
 
     def test_changing_instance_attribute_shall_change_borg_state(self):
-        self.b1.state = 'Running'
-        self.assertEqual(self.b1.state, 'Running')
-        self.assertEqual(self.b2.state, 'Running')
-        self.assertEqual(self.ib1.state, 'Running')
+        self.b1.state = "Running"
+        self.assertEqual(self.b1.state, "Running")
+        self.assertEqual(self.b2.state, "Running")
+        self.assertEqual(self.ib1.state, "Running")
 
     def test_instances_shall_have_own_ids(self):
         self.assertNotEqual(id(self.b1), id(self.b2), id(self.ib1))

--- a/tests/creational/test_builder.py
+++ b/tests/creational/test_builder.py
@@ -1,21 +1,22 @@
 import unittest
-from patterns.creational.builder import construct_building, House, Flat, ComplexHouse
+
+from patterns.creational.builder import ComplexHouse, Flat, House, construct_building
 
 
 class TestSimple(unittest.TestCase):
     def test_house(self):
         house = House()
-        self.assertEqual(house.size, 'Big')
-        self.assertEqual(house.floor, 'One')
+        self.assertEqual(house.size, "Big")
+        self.assertEqual(house.floor, "One")
 
     def test_flat(self):
         flat = Flat()
-        self.assertEqual(flat.size, 'Small')
-        self.assertEqual(flat.floor, 'More than One')
+        self.assertEqual(flat.size, "Small")
+        self.assertEqual(flat.floor, "More than One")
 
 
 class TestComplex(unittest.TestCase):
     def test_house(self):
         house = construct_building(ComplexHouse)
-        self.assertEqual(house.size, 'Big and fancy')
-        self.assertEqual(house.floor, 'One')
+        self.assertEqual(house.size, "Big and fancy")
+        self.assertEqual(house.floor, "One")

--- a/tests/creational/test_lazy.py
+++ b/tests/creational/test_lazy.py
@@ -1,28 +1,38 @@
 from __future__ import print_function
+
 import unittest
+
 from patterns.creational.lazy_evaluation import Person
 
 
 class TestDynamicExpanding(unittest.TestCase):
     def setUp(self):
-        self.John = Person('John', 'Coder')
+        self.John = Person("John", "Coder")
 
     def test_innate_properties(self):
-        self.assertDictEqual({'name': 'John', 'occupation': 'Coder', 'call_count2': 0}, self.John.__dict__)
+        self.assertDictEqual(
+            {"name": "John", "occupation": "Coder", "call_count2": 0},
+            self.John.__dict__,
+        )
 
     def test_relatives_not_in_properties(self):
-        self.assertNotIn('relatives', self.John.__dict__)
+        self.assertNotIn("relatives", self.John.__dict__)
 
     def test_extended_properties(self):
         print(u"John's relatives: {0}".format(self.John.relatives))
         self.assertDictEqual(
-            {'name': 'John', 'occupation': 'Coder', 'relatives': 'Many relatives.', 'call_count2': 0},
+            {
+                "name": "John",
+                "occupation": "Coder",
+                "relatives": "Many relatives.",
+                "call_count2": 0,
+            },
             self.John.__dict__,
         )
 
     def test_relatives_after_access(self):
         print(u"John's relatives: {0}".format(self.John.relatives))
-        self.assertIn('relatives', self.John.__dict__)
+        self.assertIn("relatives", self.John.__dict__)
 
     def test_parents(self):
         for _ in range(2):

--- a/tests/creational/test_pool.py
+++ b/tests/creational/test_pool.py
@@ -1,5 +1,5 @@
-import unittest
 import queue
+import unittest
 
 from patterns.creational.pool import ObjectPool
 
@@ -7,24 +7,24 @@ from patterns.creational.pool import ObjectPool
 class TestPool(unittest.TestCase):
     def setUp(self):
         self.sample_queue = queue.Queue()
-        self.sample_queue.put('first')
-        self.sample_queue.put('second')
+        self.sample_queue.put("first")
+        self.sample_queue.put("second")
 
     def test_items_recoil(self):
         with ObjectPool(self.sample_queue, True) as pool:
-            self.assertEqual(pool, 'first')
-        self.assertTrue(self.sample_queue.get() == 'second')
+            self.assertEqual(pool, "first")
+        self.assertTrue(self.sample_queue.get() == "second")
         self.assertFalse(self.sample_queue.empty())
-        self.assertTrue(self.sample_queue.get() == 'first')
+        self.assertTrue(self.sample_queue.get() == "first")
         self.assertTrue(self.sample_queue.empty())
 
     def test_frozen_pool(self):
         with ObjectPool(self.sample_queue) as pool:
-            self.assertEqual(pool, 'first')
-            self.assertEqual(pool, 'first')
-        self.assertTrue(self.sample_queue.get() == 'second')
+            self.assertEqual(pool, "first")
+            self.assertEqual(pool, "first")
+        self.assertTrue(self.sample_queue.get() == "second")
         self.assertFalse(self.sample_queue.empty())
-        self.assertTrue(self.sample_queue.get() == 'first')
+        self.assertTrue(self.sample_queue.get() == "first")
         self.assertTrue(self.sample_queue.empty())
 
 
@@ -36,12 +36,12 @@ class TestNaitivePool(unittest.TestCase):
 
     def test_pool_behavior_with_single_object_inside(self):
         sample_queue = queue.Queue()
-        sample_queue.put('yam')
+        sample_queue.put("yam")
         with ObjectPool(sample_queue) as obj:
             # print('Inside with: {}'.format(obj))
-            self.assertEqual(obj, 'yam')
+            self.assertEqual(obj, "yam")
         self.assertFalse(sample_queue.empty())
-        self.assertTrue(sample_queue.get() == 'yam')
+        self.assertTrue(sample_queue.get() == "yam")
         self.assertTrue(sample_queue.empty())
 
     # sample_queue.put('sam')

--- a/tests/creational/test_prototype.py
+++ b/tests/creational/test_prototype.py
@@ -1,4 +1,5 @@
 import unittest
+
 from patterns.creational.prototype import Prototype, PrototypeDispatcher
 
 
@@ -13,13 +14,13 @@ class TestPrototypeFeatures(unittest.TestCase):
 
     def test_extended_property_values_cloning(self):
         sample_object_1 = self.prototype.clone()
-        sample_object_1.some_value = 'test string'
+        sample_object_1.some_value = "test string"
         sample_object_2 = self.prototype.clone()
         self.assertRaises(AttributeError, lambda: sample_object_2.some_value)
 
     def test_cloning_propperty_assigned_values(self):
         sample_object_1 = self.prototype.clone()
-        sample_object_2 = self.prototype.clone(value='re-assigned')
+        sample_object_2 = self.prototype.clone(value="re-assigned")
         self.assertNotEqual(sample_object_1.value, sample_object_2.value)
 
 
@@ -28,20 +29,20 @@ class TestDispatcherFeatures(unittest.TestCase):
         self.dispatcher = PrototypeDispatcher()
         self.prototype = Prototype()
         c = self.prototype.clone()
-        a = self.prototype.clone(value='a-value', ext_value='E')
-        b = self.prototype.clone(value='b-value', diff=True)
-        self.dispatcher.register_object('A', a)
-        self.dispatcher.register_object('B', b)
-        self.dispatcher.register_object('C', c)
+        a = self.prototype.clone(value="a-value", ext_value="E")
+        b = self.prototype.clone(value="b-value", diff=True)
+        self.dispatcher.register_object("A", a)
+        self.dispatcher.register_object("B", b)
+        self.dispatcher.register_object("C", c)
 
     def test_batch_retrieving(self):
         self.assertEqual(len(self.dispatcher.get_objects()), 3)
 
     def test_particular_properties_retrieving(self):
-        self.assertEqual(self.dispatcher.get_objects()['A'].value, 'a-value')
-        self.assertEqual(self.dispatcher.get_objects()['B'].value, 'b-value')
-        self.assertEqual(self.dispatcher.get_objects()['C'].value, 'default')
+        self.assertEqual(self.dispatcher.get_objects()["A"].value, "a-value")
+        self.assertEqual(self.dispatcher.get_objects()["B"].value, "b-value")
+        self.assertEqual(self.dispatcher.get_objects()["C"].value, "default")
 
     def test_extended_properties_retrieving(self):
-        self.assertEqual(self.dispatcher.get_objects()['A'].ext_value, 'E')
-        self.assertTrue(self.dispatcher.get_objects()['B'].diff)
+        self.assertEqual(self.dispatcher.get_objects()["A"].ext_value, "E")
+        self.assertTrue(self.dispatcher.get_objects()["B"].diff)

--- a/tests/structural/test_adapter.py
+++ b/tests/structural/test_adapter.py
@@ -1,5 +1,6 @@
 import unittest
-from patterns.structural.adapter import Dog, Cat, Human, Car, Adapter
+
+from patterns.structural.adapter import Adapter, Car, Cat, Dog, Human
 
 
 class ClassTest(unittest.TestCase):

--- a/tests/structural/test_bridge.py
+++ b/tests/structural/test_bridge.py
@@ -1,15 +1,15 @@
 import unittest
 from unittest.mock import patch
 
-from patterns.structural.bridge import DrawingAPI1, DrawingAPI2, CircleShape
+from patterns.structural.bridge import CircleShape, DrawingAPI1, DrawingAPI2
 
 
 class BridgeTest(unittest.TestCase):
     def test_bridge_shall_draw_with_concrete_api_implementation(cls):
         ci1 = DrawingAPI1()
         ci2 = DrawingAPI2()
-        with patch.object(ci1, 'draw_circle') as mock_ci1_draw_circle, patch.object(
-            ci2, 'draw_circle'
+        with patch.object(ci1, "draw_circle") as mock_ci1_draw_circle, patch.object(
+            ci2, "draw_circle"
         ) as mock_ci2_draw_circle:
             sh1 = CircleShape(1, 2, 3, ci1)
             sh1.draw()
@@ -33,7 +33,9 @@ class BridgeTest(unittest.TestCase):
         sh2.scale(SCALE_FACTOR)
         cls.assertEqual(sh1._radius, EXPECTED_CIRCLE1_RADIUS)
         cls.assertEqual(sh2._radius, EXPECTED_CIRCLE2_RADIUS)
-        with patch.object(sh1, 'scale') as mock_sh1_scale_circle, patch.object(sh2, 'scale') as mock_sh2_scale_circle:
+        with patch.object(sh1, "scale") as mock_sh1_scale_circle, patch.object(
+            sh2, "scale"
+        ) as mock_sh2_scale_circle:
             sh1.scale(2)
             sh2.scale(2)
             cls.assertEqual(mock_sh1_scale_circle.call_count, 1)

--- a/tests/structural/test_decorator.py
+++ b/tests/structural/test_decorator.py
@@ -1,16 +1,24 @@
 import unittest
-from patterns.structural.decorator import TextTag, BoldWrapper, ItalicWrapper
+
+from patterns.structural.decorator import BoldWrapper, ItalicWrapper, TextTag
 
 
 class TestTextWrapping(unittest.TestCase):
     def setUp(self):
-        self.raw_string = TextTag('raw but not cruel')
+        self.raw_string = TextTag("raw but not cruel")
 
     def test_italic(self):
-        self.assertEqual(ItalicWrapper(self.raw_string).render(), '<i>raw but not cruel</i>')
+        self.assertEqual(
+            ItalicWrapper(self.raw_string).render(), "<i>raw but not cruel</i>"
+        )
 
     def test_bold(self):
-        self.assertEqual(BoldWrapper(self.raw_string).render(), '<b>raw but not cruel</b>')
+        self.assertEqual(
+            BoldWrapper(self.raw_string).render(), "<b>raw but not cruel</b>"
+        )
 
     def test_mixed_bold_and_italic(self):
-        self.assertEqual(BoldWrapper(ItalicWrapper(self.raw_string)).render(), '<b><i>raw but not cruel</i></b>')
+        self.assertEqual(
+            BoldWrapper(ItalicWrapper(self.raw_string)).render(),
+            "<b><i>raw but not cruel</i></b>",
+        )

--- a/tests/structural/test_proxy.py
+++ b/tests/structural/test_proxy.py
@@ -1,9 +1,9 @@
 import sys
-from time import time
 import unittest
 from io import StringIO
+from time import time
 
-from patterns.structural.proxy import Proxy, NoTalkProxy
+from patterns.structural.proxy import NoTalkProxy, Proxy
 
 
 class ProxyTest(unittest.TestCase):
@@ -24,27 +24,27 @@ class ProxyTest(unittest.TestCase):
         sys.stdout = cls.saved_stdout
 
     def test_sales_manager_shall_talk_through_proxy_with_delay(cls):
-        cls.p.busy = 'No'
+        cls.p.busy = "No"
         start_time = time()
         cls.p.talk()
         end_time = time()
         execution_time = end_time - start_time
         print_output = cls.output.getvalue()
-        expected_print_output = 'Proxy checking for Sales Manager availability\n\
-Sales Manager ready to talk\n'
+        expected_print_output = "Proxy checking for Sales Manager availability\n\
+Sales Manager ready to talk\n"
         cls.assertEqual(print_output, expected_print_output)
         expected_execution_time = 1
         cls.assertEqual(int(execution_time * 10), expected_execution_time)
 
     def test_sales_manager_shall_respond_through_proxy_with_delay(cls):
-        cls.p.busy = 'Yes'
+        cls.p.busy = "Yes"
         start_time = time()
         cls.p.talk()
         end_time = time()
         execution_time = end_time - start_time
         print_output = cls.output.getvalue()
-        expected_print_output = 'Proxy checking for Sales Manager availability\n\
-Sales Manager is busy\n'
+        expected_print_output = "Proxy checking for Sales Manager availability\n\
+Sales Manager is busy\n"
         cls.assertEqual(print_output, expected_print_output)
         expected_execution_time = 1
         cls.assertEqual(int(execution_time * 10), expected_execution_time)
@@ -68,27 +68,27 @@ class NoTalkProxyTest(unittest.TestCase):
         sys.stdout = cls.saved_stdout
 
     def test_sales_manager_shall_not_talk_through_proxy_with_delay(cls):
-        cls.ntp.busy = 'No'
+        cls.ntp.busy = "No"
         start_time = time()
         cls.ntp.talk()
         end_time = time()
         execution_time = end_time - start_time
         print_output = cls.output.getvalue()
-        expected_print_output = 'Proxy checking for Sales Manager availability\n\
-This Sales Manager will not talk to you whether he/she is busy or not\n'
+        expected_print_output = "Proxy checking for Sales Manager availability\n\
+This Sales Manager will not talk to you whether he/she is busy or not\n"
         cls.assertEqual(print_output, expected_print_output)
         expected_execution_time = 1
         cls.assertEqual(int(execution_time * 10), expected_execution_time)
 
     def test_sales_manager_shall_not_respond_through_proxy_with_delay(cls):
-        cls.ntp.busy = 'Yes'
+        cls.ntp.busy = "Yes"
         start_time = time()
         cls.ntp.talk()
         end_time = time()
         execution_time = end_time - start_time
         print_output = cls.output.getvalue()
-        expected_print_output = 'Proxy checking for Sales Manager availability\n\
-This Sales Manager will not talk to you whether he/she is busy or not\n'
+        expected_print_output = "Proxy checking for Sales Manager availability\n\
+This Sales Manager will not talk to you whether he/she is busy or not\n"
         cls.assertEqual(print_output, expected_print_output)
         expected_execution_time = 1
         cls.assertEqual(int(execution_time * 10), expected_execution_time)

--- a/tests/test_hsm.py
+++ b/tests/test_hsm.py
@@ -2,13 +2,13 @@ import unittest
 from unittest.mock import patch
 
 from patterns.other.hsm.hsm import (
+    Active,
     HierachicalStateMachine,
+    Standby,
+    Suspect,
     UnsupportedMessageType,
     UnsupportedState,
     UnsupportedTransition,
-    Active,
-    Standby,
-    Suspect,
 )
 
 
@@ -22,15 +22,15 @@ class HsmMethodTest(unittest.TestCase):
 
     def test_unsupported_state_shall_raise_exception(cls):
         with cls.assertRaises(UnsupportedState):
-            cls.hsm._next_state('missing')
+            cls.hsm._next_state("missing")
 
     def test_unsupported_message_type_shall_raise_exception(cls):
         with cls.assertRaises(UnsupportedMessageType):
-            cls.hsm.on_message('trigger')
+            cls.hsm.on_message("trigger")
 
     def test_calling_next_state_shall_change_current_state(cls):
         cls.hsm._current_state = Standby  # initial state
-        cls.hsm._next_state('active')
+        cls.hsm._next_state("active")
         cls.assertEqual(isinstance(cls.hsm._current_state, Active), True)
         cls.hsm._current_state = Standby(cls.hsm)  # initial state
 
@@ -38,7 +38,7 @@ class HsmMethodTest(unittest.TestCase):
         """ Exemplary HierachicalStateMachine method test.
         (here: _perform_switchover()). Add additional test cases... """
         return_value = cls.hsm._perform_switchover()
-        expected_return_value = 'perform switchover'
+        expected_return_value = "perform switchover"
         cls.assertEqual(return_value, expected_return_value)
 
 
@@ -54,38 +54,46 @@ class StandbyStateTest(unittest.TestCase):
         cls.hsm._current_state = Standby(cls.hsm)
 
     def test_given_standby_on_message_switchover_shall_set_active(cls):
-        cls.hsm.on_message('switchover')
+        cls.hsm.on_message("switchover")
         cls.assertEqual(isinstance(cls.hsm._current_state, Active), True)
 
     def test_given_standby_on_message_switchover_shall_call_hsm_methods(cls):
-        with patch.object(cls.hsm, '_perform_switchover') as mock_perform_switchover, patch.object(
-            cls.hsm, '_check_mate_status'
+        with patch.object(
+            cls.hsm, "_perform_switchover"
+        ) as mock_perform_switchover, patch.object(
+            cls.hsm, "_check_mate_status"
         ) as mock_check_mate_status, patch.object(
-            cls.hsm, '_send_switchover_response'
+            cls.hsm, "_send_switchover_response"
         ) as mock_send_switchover_response, patch.object(
-            cls.hsm, '_next_state'
+            cls.hsm, "_next_state"
         ) as mock_next_state:
-            cls.hsm.on_message('switchover')
+            cls.hsm.on_message("switchover")
             cls.assertEqual(mock_perform_switchover.call_count, 1)
             cls.assertEqual(mock_check_mate_status.call_count, 1)
             cls.assertEqual(mock_send_switchover_response.call_count, 1)
             cls.assertEqual(mock_next_state.call_count, 1)
 
     def test_given_standby_on_message_fault_trigger_shall_set_suspect(cls):
-        cls.hsm.on_message('fault trigger')
+        cls.hsm.on_message("fault trigger")
         cls.assertEqual(isinstance(cls.hsm._current_state, Suspect), True)
 
-    def test_given_standby_on_message_diagnostics_failed_shall_raise_exception_and_keep_in_state(cls):
+    def test_given_standby_on_message_diagnostics_failed_shall_raise_exception_and_keep_in_state(
+        cls,
+    ):
         with cls.assertRaises(UnsupportedTransition):
-            cls.hsm.on_message('diagnostics failed')
+            cls.hsm.on_message("diagnostics failed")
         cls.assertEqual(isinstance(cls.hsm._current_state, Standby), True)
 
-    def test_given_standby_on_message_diagnostics_passed_shall_raise_exception_and_keep_in_state(cls):
+    def test_given_standby_on_message_diagnostics_passed_shall_raise_exception_and_keep_in_state(
+        cls,
+    ):
         with cls.assertRaises(UnsupportedTransition):
-            cls.hsm.on_message('diagnostics passed')
+            cls.hsm.on_message("diagnostics passed")
         cls.assertEqual(isinstance(cls.hsm._current_state, Standby), True)
 
-    def test_given_standby_on_message_operator_inservice_shall_raise_exception_and_keep_in_state(cls):
+    def test_given_standby_on_message_operator_inservice_shall_raise_exception_and_keep_in_state(
+        cls,
+    ):
         with cls.assertRaises(UnsupportedTransition):
-            cls.hsm.on_message('operator inservice')
+            cls.hsm.on_message("operator inservice")
         cls.assertEqual(isinstance(cls.hsm._current_state, Standby), True)


### PR DESCRIPTION
* Added type hints and checked with `mypy`
* Formatted with `black`, `isort`, `flake8`

The second commit adds a self-contained makefile that applies black(default), sort and flake8 to the codebase. Currently, the codebase isn't normalized and different pieces of code use different formatting conventions. This aims to unify those. 

* Create and activate a `venv` 
* Run `make pylinter` and that's it

Tested on Ubuntu 20.04 and MacOS Catalina.