### PR TITLE
Update tox.ini to use py37,py38 instead of ci37,ci38

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,9 @@ sudo: false
 matrix:
   include:
     - python: "3.7"
-      env: TOXENV=ci37
+      env: TOXENV=py37
     - python: "3.8"
-      env: TOXENV=ci38
+      env: TOXENV=py38
 
 cache:
   - pip

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = ci37,ci38,cov-report
+envlist = py37,py38,cov-report
 
 
 [testenv]


### PR DESCRIPTION
As defined in the tox documentation
(https://tox.readthedocs.io/en/latest/config.html#tox-environments),
environment with names "pyNM" have special meaning and implicitly define
the Python interpreter.

Environment names ci37 and ci38 don't have any special meaning and run
the default version of the interpreter. This results in that that both
environments use the same interpreter locally.

The PR changes the names of environments to make sure that tox creates a
virtual environment with the correct interpreter version.
