### PR TITLE
Fix typo discovered by codespell

### DIFF
--- a/patterns/behavioral/publish_subscribe.py
+++ b/patterns/behavioral/publish_subscribe.py
@@ -65,7 +65,7 @@ def main():
     >>> vani.subscribe("movie")
     >>> vani.unsubscribe("movie")
 
-    # Note that no one subscirbed to `ads`
+    # Note that no one subscribed to `ads`
     # and that vani changed their mind
 
     >>> fftv.publish("cartoon")

--- a/patterns/structural/front_controller.py
+++ b/patterns/structural/front_controller.py
@@ -27,7 +27,7 @@ class Dispatcher:
         elif request.type == Request.tablet_type:
             self.tablet_view.show_index_page()
         else:
-            print("cant dispatch the request")
+            print("Cannot dispatch the request")
 
 
 class RequestController:
@@ -69,7 +69,7 @@ def main():
     Displaying tablet index page
 
     >>> front_controller.dispatch_request(Request('desktop'))
-    cant dispatch the request
+    Cannot dispatch the request
 
     >>> front_controller.dispatch_request('mobile')
     request must be a Request object


### PR DESCRIPTION
___codespell --quiet-level=2___
```
./python-patterns/patterns/behavioral/publish_subscribe.py:68: subscirbed ==> subscribed
./python-patterns/patterns/structural/front_controller.py:30: cant ==> can't
./python-patterns/patterns/structural/front_controller.py:72: cant ==> can't
```