### PR TITLE
house keeping update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ __pycache__
 venv
 .vscode/
 .python-version
+.coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,8 @@ language: python
 
 jobs:
   include:
-    - python: "3.7"
-      env: TOXENV=py37
+    - python: "3.8"
+      env: TOXENV=py38
     - python: "3.9"
       env: TOXENV=py39
 

--- a/Makefile
+++ b/Makefile
@@ -39,9 +39,8 @@ ifeq ("$(wildcard venv/bin/pip-sync)","")
 endif
 
 # pip-tools
-	@pip-compile --upgrade requirements-dev.txt
-	@pip-compile --upgrade requirements.txt
-	@pip-sync requirements-dev.txt requirements.txt
+	# @pip-compile --upgrade requirements-dev.txt
+	@pip-sync requirements-dev.txt
 
 
 .PHONY: pylinter
@@ -85,4 +84,4 @@ endif
 			--select "B,C,E,F,W,T4,B9" \
 			--ignore "E203,E266,E501,W503,F403,F401,E402" \
 			--exclude ".git,__pycache__,old, build, \
-						dist, venv" $(path)
+						dist, venv, .tox" $(path)

--- a/patterns/behavioral/iterator.py
+++ b/patterns/behavioral/iterator.py
@@ -14,8 +14,12 @@ def count_to(count):
 
 
 # Test the generator
-count_to_two = lambda: count_to(2)
-count_to_five = lambda: count_to(5)
+def count_to_two() -> None:
+    return count_to(2)
+
+
+def count_to_five() -> None:
+    return count_to(5)
 
 
 def main():

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,8 @@
 -e .
 
-pytest~=4.3.0
-pytest-cov~=2.6.0
-flake8~=3.7.0
+pytest~=6.2.0
+pytest-cov~=2.11.0
 pytest-randomly~=3.1.0
+black>=20.8b1
+isort~=5.7.0
+flake8~=3.8.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,7 @@
 [flake8]
 max-line-length = 120
 ignore = E266 E731 W503
-exclude = .venv*
+exclude = venv*
 
 [tool:pytest]
 filterwarnings =

--- a/setup.py
+++ b/setup.py
@@ -10,5 +10,7 @@ setup(
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
     ],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py37,py38,py39,cov-report
+envlist = py38,py39,cov-report
 skip_missing_interpreters = true
 
 
@@ -9,7 +9,7 @@ setenv =
 deps =
     -r requirements-dev.txt
 commands =
-    flake8 . --exclude=./.*
+    flake8 . --exclude="./.*, venv"
     ; `randomly-seed` option from `pytest-randomly` helps with deterministic outputs for examples like `other/blackboard.py`
     pytest --randomly-seed=1234 --doctest-modules patterns/
     pytest -s -vv --cov={envsitepackagesdir}/patterns --log-level=INFO tests/


### PR DESCRIPTION
Several small updates

- add .coverage to .gitignore. it is created when I run `tox`
- update minimum testing version to 3.8 (#369)
- refactor iterator.py for https://www.flake8rules.com/rules/E731.html
- update Makefile
  - comment out pip-tools part: which seems not to be used ever
  - exclude .tox from linting
- Update requirements-dev.txt
  - Add black and isort: this has been originally in Makefile.
  -  update versions
 - integrate .venv and venv into venv
 
In addition, I think it is helpful for contributors if there is info of below.
From root files, I found the way to start developing this repo is

```
git clone git@github.com:faif/python-patterns.git
cd python-patterns
python -m venv venv
pip install --upgrade pip
make pyupgrade
```

And after coding, check it by this.

```
make pylinter
tox
```