### PR TITLE
Closes #377: No return value expeced :bug:

### DIFF
--- a/patterns/creational/prototype.py
+++ b/patterns/creational/prototype.py
@@ -29,7 +29,7 @@ class Prototype:
         self.value = value
         self.__dict__.update(attrs)
 
-    def clone(self, **attrs: Any) -> None:
+    def clone(self, **attrs: Any) -> "Prototype":
         """Clone a prototype and update inner attributes dictionary"""
         # Python in Practice, Mark Summerfield
         # copy.deepcopy can be used instead of next line.


### PR DESCRIPTION
I have used class name with quotes as return type because we can not use class name before its definition.

1 file changed `.\patterns\creational\prototype.py`

```diff
@@ -29,7 +29,7 @@ def __init__(self, value: str = "default", **attrs: Any) -> None:
        self.value = value
        self.__dict__.update(attrs)

-   def clone(self, **attrs: Any) -> None:
+   def clone(self, **attrs: Any) -> "Prototype":
        """Clone a prototype and update inner attributes dictionary"""
        # Python in Practice, Mark Summerfield
        # copy.deepcopy can be used instead of next line.
```

- [x] mypy Passed
- [x] pytest doctest Passed