### PR TITLE
Replaces dead link with web archive copy

### DIFF
--- a/patterns/creational/factory.py
+++ b/patterns/creational/factory.py
@@ -12,8 +12,8 @@ in the same way independently of the language.
 
 *Where can the pattern be used practically?
 The Factory Method can be seen in the popular web framework Django:
-http://django.wikispaces.asu.edu/*NEW*+Django+Design+Patterns For
-example, in a contact form of a web page, the subject and the message
+http://web.archive.org/web/http://django.wikispaces.asu.edu/*NEW*+Django+Design+Patterns
+For example, in a contact form of a web page, the subject and the message
 fields are created using the same form factory (CharField()), even
 though they have different implementations according to their
 purposes.


### PR DESCRIPTION
Fixes #380 by using web archive link.

Unfortunately, it violates PEP-8 a bit by being longer than 80 characters, but I couldn't find a way to shorten the link further.