### PR TITLE
docs: fix simple typo, assigining -> assigning

### DIFF
--- a/patterns/creational/borg.py
+++ b/patterns/creational/borg.py
@@ -13,7 +13,7 @@ attribute dictionary called __dict__. Usually, each instance will have
 its own dictionary, but the Borg pattern modifies this so that all
 instances have the same dictionary.
 In this example, the __shared_state attribute will be the dictionary
-shared between all instances, and this is ensured by assigining
+shared between all instances, and this is ensured by assigning
 __shared_state to the __dict__ variable when initializing a new
 instance (i.e., in the __init__ method). Other attributes are usually
 added to the instance's attribute dictionary, but, since the attribute


### PR DESCRIPTION
There is a small typo in patterns/creational/borg.py.

Should read `assigning` rather than `assigining`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md