### PR TITLE
Lint sh cleanup

### DIFF
--- a/.codespellignore
+++ b/.codespellignore
@@ -1,0 +1,14 @@
+__pycache__
+*.pyc
+.idea
+*.egg-info/
+.tox/
+env/
+venv/
+.env
+.venv
+.vscode/
+.python-version
+.coverage
+build/
+dist/

--- a/lint.sh
+++ b/lint.sh
@@ -2,13 +2,15 @@
 
 pip install --upgrade pip
 pip install black codespell flake8 isort mypy pytest pyupgrade tox
-black --check .
-codespell --quiet-level=2  # --ignore-words-list="" --skip=""
-flake8 . --count --show-source --statistics
-isort --profile black .
-tox
 pip install -e .
-mypy --ignore-missing-imports . || true
-pytest .
-pytest --doctest-modules . || true
-shopt -s globstar && pyupgrade --py37-plus **/*.py
+
+source_dir="./patterns"
+
+codespell --quiet-level=2 ./patterns  # --ignore-words-list="" --skip=""
+flake8 "${source_dir}"  --count --show-source --statistics
+isort --profile black "${source_dir}"
+tox 
+mypy --ignore-missing-imports "${source_dir}" || true
+pytest "${source_dir}"
+pytest --doctest-modules "${source_dir}" || true
+shopt -s globstar && pyupgrade --py37-plus ${source_dir}/*.py

--- a/tox.ini
+++ b/tox.ini
@@ -9,10 +9,10 @@ setenv =
 deps =
     -r requirements-dev.txt
 commands =
-    flake8 . --exclude="./.*, venv"
+    flake8 --exclude="venv/,.tox/" patterns/
     ; `randomly-seed` option from `pytest-randomly` helps with deterministic outputs for examples like `other/blackboard.py`
     pytest --randomly-seed=1234 --doctest-modules patterns/
-    pytest -s -vv --cov={envsitepackagesdir}/patterns --log-level=INFO tests/
+    pytest -s -vv --cov=patterns/ --log-level=INFO tests/
 
 
 [testenv:cov-report]


### PR DESCRIPTION
Cleaned up lint.sh:
- Removed first execution of Black because Black is already executed by isort.
- Specifically directed all the linting tools to the specific location of ./patterns. By not doing so, users will experience much more noise from the linting tools when directories like venv/ and .tox/ and setup.py located in the root are being linted.
- Moved all installs of packages on top of the file, so that the rest of the output is not getting trashed by it.  
  