### PR TITLE
Highlight the need for a wrapper in delegate

### DIFF
--- a/patterns/fundamental/delegation_pattern.py
+++ b/patterns/fundamental/delegation_pattern.py
@@ -19,13 +19,15 @@ class Delegator:
     >>> delegator.p2
     Traceback (most recent call last):
     ...
-    AttributeError: 'Delegate' object has no attribute 'p2'
+    AttributeError: 'Delegate' object has no attribute 'p2'. Did you mean: 'p1'?
     >>> delegator.do_something("nothing")
     'Doing nothing'
+    >>> delegator.do_something("something", kw=", faif!")
+    'Doing something, faif!'
     >>> delegator.do_anything()
     Traceback (most recent call last):
     ...
-    AttributeError: 'Delegate' object has no attribute 'do_anything'
+    AttributeError: 'Delegate' object has no attribute 'do_anything'. Did you mean: 'do_something'?
     """
 
     def __init__(self, delegate: Delegate) -> None:
@@ -47,8 +49,8 @@ class Delegate:
     def __init__(self) -> None:
         self.p1 = 123
 
-    def do_something(self, something: str) -> str:
-        return f"Doing {something}"
+    def do_something(self, something: str, kw=None) -> str:
+        return f"Doing {something}{kw or ''}"
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
- It's required to capture the args/kwargs when called at run time.
- Fix doctest output to include hints

Addresses: #431 