### PR TITLE
fix(docs): correct typos in top comment of catalog.py

### DIFF
--- a/patterns/behavioral/catalog.py
+++ b/patterns/behavioral/catalog.py
@@ -1,5 +1,5 @@
 """
-A class that uses different static function depending of a parameter passed in
+A class that uses different static functions depending on a parameter passed in
 init. Note the use of a single dictionary instead of multiple conditions
 """
 


### PR DESCRIPTION
This PR fixes minor typos in the top-level docstring of patterns/behavoural/catalog.py

Changes

Corrected "depending of" -> "depending on"
Changed "static function" -> "static functions"

Why

Improves readability and correctness of documentation