### PR TITLE
fix: :bug: Fix potential warning in factory.py

### DIFF
--- a/patterns/creational/factory.py
+++ b/patterns/creational/factory.py
@@ -26,8 +26,7 @@ from typing import Dict, Protocol, Type
 
 
 class Localizer(Protocol):
-    def localize(self, msg: str) -> str:
-        pass
+    def localize(self, msg: str) -> str: ...
 
 
 class GreekLocalizer:


### PR DESCRIPTION
Use ellipsis replace pass to avoid potential warning:

```json
	"resource": "/d:/Github/Python/python-patterns/patterns/creational/factory.py",
	"owner": "pylance4",
		"value": "reportReturnType",
			"path": "/microsoft/pylance-release/blob/main/docs/diagnostics/reportReturnType.md",
	"severity": 8,
	"message": "Function with declared return type \"str\" must return value on all code paths\n  \"None\" is not assignable to \"str\"",
	"source": "Pylance",
	"startLineNumber": 29,
	"startColumn": 37,
	"endLineNumber": 29,
	"endColumn": 40,
	"origin": "extHost1"
```

Using VS Code with Pylance, Python debugger, and Black Formatter.