### PR TITLE
docs: Add missing Servant pattern to README behavioral patterns table

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ __Behavioral Patterns__:
 | [observer](patterns/behavioral/observer.py) | provide a callback for notification of events/changes to data |
 | [publish_subscribe](patterns/behavioral/publish_subscribe.py) | a source syndicates events/data to 0+ registered listeners |
 | [registry](patterns/behavioral/registry.py) | keep track of all subclasses of a given class |
+| [servant](patterns/behavioral/servant.py) | provide common functionality to a group of classes without using inheritance |
 | [specification](patterns/behavioral/specification.py) |  business rules can be recombined by chaining the business rules together using boolean logic |
 | [state](patterns/behavioral/state.py) | logic is organized into a discrete number of potential states and the next state that can be transitioned to |
 | [strategy](patterns/behavioral/strategy.py) | selectable operations over the same data |


### PR DESCRIPTION
## Description
This PR adds the missing **Servant** design pattern entry to the README's Behavioral Patterns table.

## Problem
The Servant pattern was fully implemented in [patterns/behavioral/servant.py](cci:7://file:///d:/Ninja_Work/Git_work/python-patterns/patterns/behavioral/servant.py:0:0-0:0) with:
- ✅ Complete implementation with proper docstrings
- ✅ Working examples and doctests
- ✅ Unit tests in [tests/behavioral/test_servant.py](cci:7://file:///d:/Ninja_Work/Git_work/python-patterns/tests/behavioral/test_servant.py:0:0-0:0)

However, it was **not documented** in the README.md's Behavioral Patterns table, making it invisible to users browsing the repository.

## Solution
Added the Servant pattern entry to the Behavioral Patterns table in alphabetical order:
```markdown
| [servant](patterns/behavioral/servant.py) | provide common functionality to a group of classes without using inheritance |