### PR TITLE
Fixed an incorrect indentation

### DIFF
--- a/patterns/creational/factory.py
+++ b/patterns/creational/factory.py
@@ -54,8 +54,7 @@ def get_localizer(language: str = "English") -> Localizer:
         "Greek": GreekLocalizer,
     }
 
-        return localizers.get(language, EnglishLocalizer)()
-
+    return localizers.get(language, EnglishLocalizer)()
 
 
 def main():


### PR DESCRIPTION
- Fixed an incorrect indentation bug

```
patterns/creational/factory.py:None (patterns/creational/factory.py)
.venv/lib/python3.13/site-packages/_pytest/python.py:507: in importtestmodule
    mod = import_path(
.venv/lib/python3.13/site-packages/_pytest/pathlib.py:587: in import_path
    importlib.import_module(module_name)
../../.local/share/uv/python/cpython-3.13.9-macos-aarch64-none/lib/python3.13/importlib/__init__.py:88: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
<frozen importlib._bootstrap>:1387: in _gcd_import
    ???
<frozen importlib._bootstrap>:1360: in _find_and_load
    ???
<frozen importlib._bootstrap>:1331: in _find_and_load_unlocked
    ???
<frozen importlib._bootstrap>:935: in _load_unlocked
    ???
.venv/lib/python3.13/site-packages/_pytest/assertion/rewrite.py:188: in exec_module
    source_stat, co = _rewrite_test(fn, self.config)
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
.venv/lib/python3.13/site-packages/_pytest/assertion/rewrite.py:357: in _rewrite_test
    tree = ast.parse(source, filename=strfn)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
../../.local/share/uv/python/cpython-3.13.9-macos-aarch64-none/lib/python3.13/ast.py:50: in parse
    return compile(source, filename, mode, flags,
E     File "/python-patterns/patterns/creational/factory.py", line 57
E       return localizers.get(language, EnglishLocalizer)()
E   IndentationError: unexpected indent

Process finished with exit code 2
```