### PR TITLE
Add unit tests for MVC/Facade/Flyweight/Delegation and small fixes to enable pytest collection

### DIFF
--- a/patterns/behavioral/memento.py
+++ b/patterns/behavioral/memento.py
@@ -6,7 +6,7 @@ Provides the ability to restore an object to its previous state.
 """
 
 from copy import copy, deepcopy
-from typing import Callable, List
+from typing import Any, Callable, List, Type
 
 
 def memento(obj: Any, deep: bool = False) -> Callable:

--- a/patterns/structural/mvc.py
+++ b/patterns/structural/mvc.py
@@ -4,7 +4,6 @@ Separates data in GUIs from the ways it is presented, and accepted.
 """
 
 from abc import ABC, abstractmethod
-from ProductModel import Price
 from typing import Dict, List, Union, Any
 from inspect import signature
 from sys import argv

--- a/pytest_local.ini
+++ b/pytest_local.ini
@@ -1,0 +1,3 @@
+[pytest]
+addopts = -q
+testpaths = tests

--- a/tests/fundamental/test_delegation.py
+++ b/tests/fundamental/test_delegation.py
@@ -1,0 +1,16 @@
+import pytest
+
+from patterns.fundamental.delegation_pattern import Delegator, Delegate
+
+
+def test_delegator_delegates_attribute_and_call():
+    d = Delegator(Delegate())
+    assert d.p1 == 123
+    assert d.do_something("something") == "Doing something"
+    assert d.do_something("something", kw=", hi") == "Doing something, hi"
+
+
+def test_delegator_missing_attribute_raises():
+    d = Delegator(Delegate())
+    with pytest.raises(AttributeError):
+        _ = d.p2

--- a/tests/structural/test_facade.py
+++ b/tests/structural/test_facade.py
@@ -1,0 +1,11 @@
+from patterns.structural.facade import ComputerFacade
+
+
+def test_computer_facade_start(capsys):
+    cf = ComputerFacade()
+    cf.start()
+    out = capsys.readouterr().out
+    assert "Freezing processor." in out
+    assert "Loading from 0x00 data:" in out
+    assert "Jumping to: 0x00" in out
+    assert "Executing." in out

--- a/tests/structural/test_flyweight.py
+++ b/tests/structural/test_flyweight.py
@@ -1,0 +1,20 @@
+from patterns.structural.flyweight import Card
+
+
+def test_card_flyweight_identity_and_repr():
+    c1 = Card("9", "h")
+    c2 = Card("9", "h")
+    assert c1 is c2
+    assert repr(c1) == "<Card: 9h>"
+
+
+def test_card_attribute_persistence_and_pool_clear():
+    Card._pool.clear()
+    c1 = Card("A", "s")
+    c1.temp = "t"
+    c2 = Card("A", "s")
+    assert hasattr(c2, "temp")
+
+    Card._pool.clear()
+    c3 = Card("A", "s")
+    assert not hasattr(c3, "temp")

--- a/tests/structural/test_mvc.py
+++ b/tests/structural/test_mvc.py
@@ -1,0 +1,67 @@
+import pytest
+
+from patterns.structural.mvc import (
+    ProductModel,
+    ConsoleView,
+    Controller,
+    Router,
+)
+
+
+def test_productmodel_iteration_and_price_str():
+    pm = ProductModel()
+    items = list(pm)
+    assert set(items) == {"milk", "eggs", "cheese"}
+
+    info = pm.get("cheese")
+    assert info["quantity"] == 10
+    assert str(info["price"]) == "2.00"
+
+
+def test_productmodel_get_raises_keyerror():
+    pm = ProductModel()
+    with pytest.raises(KeyError) as exc:
+        pm.get("unknown_item")
+    assert "not in the model's item list." in str(exc.value)
+
+
+def test_consoleview_capitalizer_and_list_and_info(capsys):
+    view = ConsoleView()
+    # capitalizer
+    assert view.capitalizer("heLLo") == "Hello"
+
+    # show item list
+    view.show_item_list("product", ["x", "y"])
+    out = capsys.readouterr().out
+    assert "PRODUCT LIST:" in out
+    assert "x" in out and "y" in out
+
+    # show item information formatting
+    pm = ProductModel()
+    controller = Controller(pm, view)
+    controller.show_item_information("milk")
+    out = capsys.readouterr().out
+    assert "PRODUCT INFORMATION:" in out
+    assert "Name: milk" in out
+    assert "Price: 1.50" in out
+    assert "Quantity: 10" in out
+
+
+def test_show_item_information_missing_calls_item_not_found(capsys):
+    view = ConsoleView()
+    pm = ProductModel()
+    controller = Controller(pm, view)
+
+    controller.show_item_information("arepas")
+    out = capsys.readouterr().out
+    assert 'That product "arepas" does not exist in the records' in out
+
+
+def test_router_register_resolve_and_unknown():
+    router = Router()
+    router.register("products", Controller, ProductModel, ConsoleView)
+    controller = router.resolve("products")
+    assert isinstance(controller, Controller)
+
+    with pytest.raises(KeyError):
+        router.resolve("no-such-path")


### PR DESCRIPTION
**Summary**: Add focused unit tests for several low-coverage modules and apply two minimal source fixes so the test suite can be collected and run reliably in CI/local dev.
**Why**: Running pytest previously failed during collection due to a missing import and missing typing names; these prevented adding tests and measuring coverage. This PR adds tests and the smallest safe changes needed to run them.
**What I changed (files):**
**Added tests:**
test_mvc.py
test_facade.py
test_flyweight.py
test_delegation.py
pytest_local.ini (temporary local pytest config to avoid project-wide doctest addopts during targeted runs)
**Small source fixes:**
mvc.py — removed invalid top-level from ProductModel import Price (module did not exist; file defines its own Price class).
memento.py — added missing typing imports (Any, Type) to avoid NameError during collection.