### PR TITLE
chore: Update outdated GitHub Actions versions

### DIFF
--- a/.github/workflows/lint_pr.yml
+++ b/.github/workflows/lint_pr.yml
@@ -7,7 +7,7 @@ jobs:
       has_python_changes: ${{ steps.changed-files.outputs.has_python_changes }}
       files: ${{ steps.changed-files.outputs.files }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0 # To get all history for git diff commands
 
@@ -71,15 +71,15 @@ jobs:
             exit 0
           fi
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v6
         with:
           python-version: 3.12
 
-      - uses: actions/cache@v3
+      - uses: actions/cache@v5
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-${{ hashFiles('requirements-dev.txt') }}
@@ -273,7 +273,7 @@ jobs:
     if: ${{ always() }}
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
 
       - name: Summarize results
         run: |

--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -4,8 +4,8 @@ jobs:
   lint_python:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: 3.12
       - name: Install dependencies


### PR DESCRIPTION
This PR updates outdated GitHub Action versions.

- Updated `actions/setup-python` from `v4` to `v6` in `.github/workflows/lint_python.yml`
- Updated `actions/cache` from `v3` to `v5` in `.github/workflows/lint_pr.yml`
- Updated `actions/checkout` from `v3` to `v6` in `.github/workflows/lint_pr.yml`
- Updated `actions/setup-python` from `v4` to `v6` in `.github/workflows/lint_pr.yml`
- Updated `actions/checkout` from `v3` to `v6` in `.github/workflows/lint_python.yml`
